### PR TITLE
Refactor filters from crud model to get/set model with objects representing each level instead of targets.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "editor.tabSize": 4,
+  "editor.insertSpaces": true
+}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "http-post-message": "^0.2.0",
-    "powerbi-models": "^0.5.0",
+    "powerbi-models": "^0.7.2",
     "powerbi-router": "^0.1.2",
     "window-post-message-proxy": "^0.2.1"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 const config = {
-  version: '2.0.0-beta.7',
+  version: '2.0.0-beta.8',
   type: 'js'
 };
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -97,7 +97,11 @@ export abstract class Embed {
      *     navContentPaneEnabled: false
      *   },
      *   pageName: "DefaultPage",
-     *   filte: "DefaultReportFilter"
+     *   filters: [
+     *     {
+     *        ...  DefaultReportFilter ...
+     *     }
+     *   ]
      * })
      *   .catch(error => { ... });
      * ```

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -109,7 +109,10 @@ export abstract class Embed {
         }
 
         return this.service.hpm.post<void>('/report/load', config, { uid: this.config.uniqueId }, this.iframe.contentWindow)
-            .catch(response => {
+            .then(response => {
+                return response.body;
+            },
+            response => {
                 throw response.body;
             });
     }

--- a/src/ifilterable.ts
+++ b/src/ifilterable.ts
@@ -1,0 +1,7 @@
+import * as models from 'powerbi-models';
+
+export interface IFilterable {
+    getFilters(): Promise<(models.IBasicFilter | models.IAdvancedFilter)[]>;
+    setFilters(filters: (models.IBasicFilter | models.IAdvancedFilter)[]): Promise<void>;
+    removeFilters(): Promise<void>;
+}

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,0 +1,119 @@
+import { IFilterable } from './ifilterable';
+import { IReport } from './report';
+import { Visual } from './visual';
+import * as models from 'powerbi-models';
+
+export interface IPage {
+    report: IReport;
+    name: string;
+    displayName: string;
+    setActive(): void;
+}
+
+export class Page implements IPage, IFilterable {
+    report: IReport;
+    name: string;
+    // This can be undefined in cases where page is created manually
+    displayName: string;
+
+    constructor(report: IReport, name: string, displayName?: string) {
+        this.report = report;
+        this.name = name;
+        this.displayName = displayName;
+    }
+
+    /**
+     * Gets all page level filters within report
+     * 
+     * ```javascript
+     * page.getFilters()
+     *  .then(pages => { ... });
+     * ```
+     */
+    getFilters() {
+        return this.report.service.hpm.get<models.IFilter[]>(`/report/pages/${this.name}/filters`, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
+            .then(response => response.body,
+            response => {
+                throw response.body;
+            });
+    }
+
+    /**
+     * Gets all the visuals on the page.
+     * 
+     * ```javascript
+     * page.getVisuals()
+     *   .then(visuals => { ... });
+     * ```
+     */
+    getVisuals() {
+        return this.report.service.hpm.get<models.IVisual[]>(`/report/pages/${this.name}/visuals`, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
+            .then(response => response.body,
+            response => {
+                throw response.body;
+            });
+    }
+
+    /**
+     * Remove all filters on this page within the report
+     * 
+     * ```javascript
+     * page.removeFilters();
+     * ```
+     */
+    removeFilters() {
+        return this.setFilters([]);
+    }
+
+    /**
+     * Make the current page the active page of the report.
+     * 
+     * ```javascripot
+     * page.setActive();
+     * ```
+     */
+    setActive() {
+        const page: models.IPage = {
+            name: this.name,
+            displayName: null
+        };
+
+        return this.report.service.hpm.put<models.IError[]>('/report/pages/active', page, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
+            .catch(response => {
+                throw response.body;
+            });
+    }
+
+    /**
+     * Sets all filters on the current page.
+     * 
+     * ```javascript
+     * page.setFilters(filters);
+     *   .catch(errors => { ... });
+     * ```
+     */
+    setFilters(filters: (models.IBasicFilter | models.IAdvancedFilter)[]) {
+        return this.report.service.hpm.put<models.IError[]>(`/report/pages/${this.name}/filters`, filters, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
+            .catch(response => {
+                throw response.body;
+            });
+    }
+
+    /**
+     * Creates new Visual object given a name of the visual.
+     * 
+     * Normally you would get Visual objects by calling `page.getVisuals()` but in the case
+     * that the visual name is known and you want to perform an action on a visaul such as setting a filters
+     * without having to retrieve it first you can create it directly.
+     * 
+     * Note: Since you are creating the visual manually there is no guarantee that the visual actually exists in the report and the subsequence requests could fail.
+     * 
+     * ```javascript
+     * const visual = report.page('ReportSection1').visual('BarChart1');
+     * visual.setFilters(filters);
+     * ```
+     */
+    visual(name: string): Visual {
+        return new Visual(this, name);
+    }
+}

--- a/src/page.ts
+++ b/src/page.ts
@@ -46,10 +46,14 @@ export class Page implements IPage, IFilterable {
      *   .then(visuals => { ... });
      * ```
      */
-    getVisuals() {
+    getVisuals(): Promise<Visual[]> {
         return this.report.service.hpm.get<models.IVisual[]>(`/report/pages/${this.name}/visuals`, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
-            .then(response => response.body,
-            response => {
+            .then(response => {
+                return response.body
+                    .map(visual => {
+                        return new Visual(this, visual.name);
+                    });
+            }, response => {
                 throw response.body;
             });
     }

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,22 +1,20 @@
 import { IFilterable } from './ifilterable';
-import { IReport } from './report';
+import { IReportNode } from './report';
 import { Visual } from './visual';
 import * as models from 'powerbi-models';
 
-export interface IPage {
-    report: IReport;
+export interface IPageNode {
+    report: IReportNode;
     name: string;
-    displayName: string;
-    setActive(): void;
 }
 
-export class Page implements IPage, IFilterable {
-    report: IReport;
+export class Page implements IPageNode, IFilterable {
+    report: IReportNode;
     name: string;
     // This can be undefined in cases where page is created manually
     displayName: string;
 
-    constructor(report: IReport, name: string, displayName?: string) {
+    constructor(report: IReportNode, name: string, displayName?: string) {
         this.report = report;
         this.name = name;
         this.displayName = displayName;

--- a/src/report.ts
+++ b/src/report.ts
@@ -5,15 +5,15 @@ import * as wpmp from 'window-post-message-proxy';
 import * as hpm from 'http-post-message';
 import * as utils from './util';
 import { IFilterable } from './ifilterable';
-import { IPage, Page } from './page';
+import { IPageNode, Page } from './page';
 
-export interface IReport {
+export interface IReportNode {
     iframe: HTMLIFrameElement;
     service: service.IService;
     config: embed.IInternalEmbedConfiguration
 }
 
-export class Report extends embed.Embed implements IReport, IFilterable {
+export class Report extends embed.Embed implements IReportNode, IFilterable {
     static allowedEvents = ["dataSelected", "filtersApplied", "pageChanged", "error"];
     static reportIdAttribute = 'powerbi-report-id';
     static filterPaneEnabledAttribute = 'powerbi-settings-filter-pane-enabled';

--- a/src/report.ts
+++ b/src/report.ts
@@ -94,7 +94,7 @@ export class Report extends embed.Embed implements IReport, IFilterable {
      *  });
      * ```
      */
-    getPages(): Promise<IPage[]> {
+    getPages(): Promise<Page[]> {
         return this.service.hpm.get<models.IPage[]>('/report/pages', { uid: this.config.uniqueId }, this.iframe.contentWindow)
             .then(response => {
                 return response.body

--- a/src/report.ts
+++ b/src/report.ts
@@ -4,9 +4,17 @@ import * as models from 'powerbi-models';
 import * as wpmp from 'window-post-message-proxy';
 import * as hpm from 'http-post-message';
 import * as utils from './util';
+import { IFilterable } from './ifilterable';
+import { IPage, Page } from './page';
 
-export class Report extends embed.Embed {
-    static allowedEvents = ["dataSelected", "filterAdded", "filterUpdated", "filterRemoved", "pageChanged", "error"];
+export interface IReport {
+    iframe: HTMLIFrameElement;
+    service: service.IService;
+    config: embed.IInternalEmbedConfiguration
+}
+
+export class Report extends embed.Embed implements IReport, IFilterable {
+    static allowedEvents = ["dataSelected", "filtersApplied", "pageChanged", "error"];
     static reportIdAttribute = 'powerbi-report-id';
     static filterPaneEnabledAttribute = 'powerbi-settings-filter-pane-enabled';
     static navContentPaneEnabledAttribute = 'powerbi-settings-nav-content-pane-enabled';
@@ -35,9 +43,9 @@ export class Report extends embed.Embed {
     static findIdFromEmbedUrl(url: string): string {
         const reportIdRegEx = /reportId="?([^&]+)"?/
         const reportIdMatch = url.match(reportIdRegEx);
-        
+
         let reportId;
-        if(reportIdMatch) {
+        if (reportIdMatch) {
             reportId = reportIdMatch[1];
         }
 
@@ -45,31 +53,7 @@ export class Report extends embed.Embed {
     }
 
     /**
-     * Add filter to report
-     * An optional target may be passed to apply the filter to specific page or visual.
-     * 
-     * ```javascript
-     * // Add filter to report
-     * const filter = new models.BasicFilter(...);
-     * report.addFilter(filter);
-     * 
-     * // Add advanced filter to specific visual;
-     * const target = ...
-     * const filter = new models.AdvancedFilter(...);
-     * report.addFilter(filter, target);
-     * ```
-     */
-    addFilter(filter: models.IFilter, target?: models.IPageTarget | models.IVisualTarget): Promise<void> {
-        const targetUrl = this.getTargetUrl(target);
-        return this.service.hpm.post<void>(`${targetUrl}/filters`, filter, { uid: this.config.uniqueId }, this.iframe.contentWindow)
-            .catch(response => {
-                throw response.body;
-            });
-    }
-
-    /**
-     * Get filters that are applied to the report
-     * An optional target may be passed to get filters applied to a specific page or visual
+     * Get filters that are applied at the report level
      * 
      * ```javascript
      * // Get filters applied at report level
@@ -77,25 +61,14 @@ export class Report extends embed.Embed {
      *   .then(filters => {
      *     ...
      *   });
-     * 
-     * // Get filters applied at page level
-     * const pageTarget = {
-     *   name: "reportSection1"
-     * };
-     * 
-     * report.getFilters(pageTarget)
-     *   .then(filters => {
-     *       ...
-     *   });
      * ```
      */
-    getFilters(target?: models.IPageTarget | models.IVisualTarget): Promise<models.IFilter[]> {
-        const targetUrl = this.getTargetUrl(target);
-        return this.service.hpm.get<models.IFilter[]>(`${targetUrl}/filters`, { uid: this.config.uniqueId }, this.iframe.contentWindow)
+    getFilters(): Promise<models.IFilter[]> {
+        return this.service.hpm.get<models.IFilter[]>(`/report/filters`, { uid: this.config.uniqueId }, this.iframe.contentWindow)
             .then(response => response.body,
-                response => {
-                    throw response.body;
-                });
+            response => {
+                throw response.body;
+            });
     }
 
     /**
@@ -121,14 +94,47 @@ export class Report extends embed.Embed {
      *  });
      * ```
      */
-    getPages(): Promise<models.IPage[]> {
+    getPages(): Promise<IPage[]> {
         return this.service.hpm.get<models.IPage[]>('/report/pages', { uid: this.config.uniqueId }, this.iframe.contentWindow)
-            .then(response => response.body,
-                response => {
-                    throw response.body;
-                });
+            .then(response => {
+                return response.body
+                    .map(page => {
+                        return new Page(this, page.name);
+                    });
+            }, response => {
+                throw response.body;
+            });
     }
-    
+
+    /**
+     * Create new Page instance.
+     * 
+     * Normally you would get Page objects by calling `report.getPages()` but in the case
+     * that the page name is known and you want to perform an action on a page without having to retrieve it
+     * you can create it directly.
+     * 
+     * Note: Since you are creating the page manually there is no guarantee that the page actually exists in the report and the subsequence requests could fail.
+     * 
+     * ```javascript
+     * const page = report.page('ReportSection1');
+     * page.setActive();
+     * ```
+     */
+    page(name: string): Page {
+        return new Page(this, name);
+    }
+
+    /**
+     * Remove all filters at report level
+     * 
+     * ```javascript
+     * report.removeFilters();
+     * ```
+     */
+    removeFilters() {
+        return this.setFilters([]);
+    }
+
     /**
      * Set the active page
      * 
@@ -150,56 +156,21 @@ export class Report extends embed.Embed {
     }
 
     /**
-     * Remove specific filter from report, page, or visual
+     * Sets filters
      * 
      * ```javascript
-     * const filter = new models.BasicFilter(...);
+     * const filters: [
+     *    ...
+     * ];
      * 
-     * report.removeFilter(filter)
-     *  .catch(error => { ... });
+     * report.setFilters(filters)
+     *  .catch(errors => {
+     *    ...
+     *  });
      * ```
      */
-    removeFilter(filter: models.IFilter, target?: models.IPageTarget | models.IVisualTarget): Promise<void> {
-        const targetUrl = this.getTargetUrl(target);
-        return this.service.hpm.delete<models.IError[]>(`${targetUrl}/filters`, filter, { uid: this.config.uniqueId }, this.iframe.contentWindow)
-            .catch(response => {
-                throw response.body;
-            });
-    }
-
-    /**
-     * Remove all filters across the report, pages, and visuals
-     * 
-     * ```javascript
-     * report.removeAllFilters();
-     * ```
-     */
-    removeAllFilters(target?: models.IPageTarget | models.IVisualTarget): Promise<void> {
-        const targetUrl = this.getTargetUrl(target);
-        return this.service.hpm.delete<models.IError[]>(`${targetUrl}/allfilters`, null, { uid: this.config.uniqueId }, this.iframe.contentWindow)
-            .catch(response => {
-                throw response.body;
-            });
-    }
-    
-    /**
-     * Update existing filter applied to report, page, or visual.
-     * 
-     * The existing filter will be replaced with the new filter.
-     * 
-     * ```javascript
-     * const filter = new models.BasicFilter(...);
-     * const target = {
-     *   type: "page",
-     *   name: "ReportSection2"
-     * };
-     * 
-     * report.updateFilter(filter, target)
-     *  .catch(errors => { ... });
-     */
-    updateFilter(filter: models.IFilter, target?: models.IPageTarget | models.IVisualTarget): Promise<void> {
-        const targetUrl = this.getTargetUrl(target);
-        return this.service.hpm.put<models.IError[]>(`${targetUrl}/filters`, filter, { uid: this.config.uniqueId }, this.iframe.contentWindow)
+    setFilters(filters: (models.IBasicFilter | models.IAdvancedFilter)[]): Promise<void> {
+        return this.service.hpm.put<models.IError[]>(`/report/filters`, filters, { uid: this.config.uniqueId }, this.iframe.contentWindow)
             .catch(response => {
                 throw response.body;
             });
@@ -223,34 +194,5 @@ export class Report extends embed.Embed {
             .catch(response => {
                 throw response.body;
             });
-    }
-
-    /**
-     * Translate target into url
-     * Target may be to the whole report, speific page, or specific visual
-     */
-    private getTargetUrl(target?: models.IPageTarget | models.IVisualTarget): string {
-        let targetUrl;
-
-        /**
-         * TODO: I mentioned this issue in the protocol test, but we're tranlating targets from objects
-         * into parts of the url, and then back to objects. It is a trade off between complixity in this code vs semantic URIs
-         * 
-         * We could come up with a different idea which passed the target as part of the body
-         */
-        if(!target) {
-            targetUrl = '/report';
-        }
-        else if(target.type === "page") {
-            targetUrl = `/report/pages/${(<models.IPageTarget>target).name}`;
-        }
-        else if(target.type === "visual") {
-            targetUrl = `/report/visuals/${(<models.IVisualTarget>target).id}`;
-        }
-        else {
-            throw new Error(`target.type must be either 'page' or 'visual'. You passed: ${target.type}`);
-        }
-
-        return targetUrl;
     }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -114,7 +114,7 @@ export class Service implements IService {
 
             this.handleEvent(event);
         });
-        this.router.post(`/reports/:uniqueId/visuals/:pageName/events/:eventName`, (req, res) => {
+        this.router.post(`/reports/:uniqueId/pages/:pageName/visuals/:pageName/events/:eventName`, (req, res) => {
             const event: IEvent<any> = {
                 type: 'report',
                 id: req.params.uniqueId,

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,7 @@
 import * as embed from './embed';
 import { Report } from './report';
 import { Tile } from './tile';
+import { Page } from './page';
 import * as utils from './util';
 import * as wpmp from 'window-post-message-proxy';
 import * as hpm from 'http-post-message';
@@ -48,6 +49,10 @@ export interface IServiceConfiguration extends IDebugOptions {
     onError?: (error: any) => any;
     version?: string;
     type?: string;
+}
+
+export interface IService {
+    hpm: hpm.HttpPostMessage;
 }
 
 export class Service {
@@ -261,36 +266,13 @@ export class Service {
         }, this.embeds);
 
         if(embed) {
-            utils.raiseCustomEvent(embed.element, event.name, event.value);
-        }
-    }
+            let value = event.value;
 
-    /**
-     * Translate target into url
-     * Target may be to the whole report, speific page, or specific visual
-     */
-    private getTargetUrl(target?: models.IPageTarget | models.IVisualTarget): string {
-        let targetUrl;
+            if (event.name === 'pageChanged') {
+                value.page = new Page(embed, event.value.page.name);
+            }
 
-        /**
-         * TODO: I mentioned this issue in the protocol test, but we're tranlating targets from objects
-         * into parts of the url, and then back to objects. It is a trade off between complixity in this code vs semantic URIs
-         * 
-         * We could come up with a different idea which passed the target as part of the body
-         */
-        if(!target) {
-            targetUrl = '/report';
+            utils.raiseCustomEvent(embed.element, event.name, value);
         }
-        else if(target.type === "page") {
-            targetUrl = `/report/pages/${(<models.IPageTarget>target).name}`;
-        }
-        else if(target.type === "visual") {
-            targetUrl = `/report/visuals/${(<models.IVisualTarget>target).id}`;
-        }
-        else {
-            throw new Error(`target.type must be either 'page' or 'visual'. You passed: ${target.type}`);
-        }
-
-        return targetUrl;
     }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -55,7 +55,7 @@ export interface IService {
     hpm: hpm.HttpPostMessage;
 }
 
-export class Service {
+export class Service implements IService {
 
     /**
      * List of components this service can embed.

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,17 +12,6 @@ export function raiseCustomEvent(element: HTMLElement, eventName: string, eventD
     }
 
     element.dispatchEvent(customEvent);
-    if (customEvent.defaultPrevented || !customEvent.returnValue) {
-        return;
-    }
-
-    // TODO: Remove this? Should be better way to handle events than using eval?
-    // What is use case? <div powerbi-type="report" onload="alert('loaded');"></div>
-    const inlineEventAttr = 'on' + eventName.replace('-', '');
-    const inlineScript = element.getAttribute(inlineEventAttr);
-    if (inlineScript) {
-        eval.call(element, inlineScript);
-    }
 }
 
 export function findIndex<T>(predicate: (x: T) => boolean, xs: T[]): number {

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -1,17 +1,17 @@
 import * as models from 'powerbi-models';
 import { IFilterable } from './ifilterable';
-import { IPage, Page } from './page';
+import { IPageNode, Page } from './page';
 
-export interface IVisual {
+export interface IVisualNode {
     name: string;
-    page: IPage;
+    page: IPageNode;
 }
 
-export class Visual implements IVisual, IFilterable {
+export class Visual implements IVisualNode, IFilterable {
     name: string;
-    page: IPage;
+    page: IPageNode;
 
-    constructor(page: IPage, name: string) {
+    constructor(page: IPageNode, name: string) {
         this.name = name;
         this.page = page;
     }

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -1,0 +1,60 @@
+import * as models from 'powerbi-models';
+import { IFilterable } from './ifilterable';
+import { IPage, Page } from './page';
+
+export interface IVisual {
+    name: string;
+    page: IPage;
+}
+
+export class Visual implements IVisual, IFilterable {
+    name: string;
+    page: IPage;
+
+    constructor(page: IPage, name: string) {
+        this.name = name;
+        this.page = page;
+    }
+
+    /**
+     * Gets all page level filters within report
+     * 
+     * ```javascript
+     * visual.getFilters()
+     *  .then(pages => { ... });
+     * ```
+     */
+    getFilters() {
+        return this.page.report.service.hpm.get<models.IFilter[]>(`/report/pages/${this.page.name}/visuals/${this.name}/filters`, { uid: this.page.report.config.uniqueId }, this.page.report.iframe.contentWindow)
+            .then(response => response.body,
+            response => {
+                throw response.body;
+            });
+    }
+
+    /**
+     * Remove all filters on this page within the report
+     * 
+     * ```javascript
+     * visual.removeFilters();
+     * ```
+     */
+    removeFilters() {
+        return this.setFilters([]);
+    }
+
+    /**
+     * Set all filters at the visual level of the page
+     * 
+     * ```javascript
+     * visual.setFilters(filters)
+     *  .catch(errors => { ... });
+     * ```
+     */
+    setFilters(filters: (models.IBasicFilter | models.IAdvancedFilter)[]) {
+        return this.page.report.service.hpm.put<models.IError[]>(`/report/pages/${this.page.name}/visuals/${this.name}/filters`, filters, { uid: this.page.report.config.uniqueId }, this.page.report.iframe.contentWindow)
+            .catch(response => {
+                throw response.body;
+            });
+    }
+}

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -2343,7 +2343,8 @@ describe('SDK-to-HPM', function () {
           .then(visuals => {
             // Assert
             expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${page1.name}/visuals`, { uid: uniqueId }, iframe.contentWindow);
-            expect(visuals).toEqual(testData.response.body);
+            expect(visuals[0].name).toEqual(testData.response.body[0].name);
+            expect(visuals[1].name).toEqual(testData.response.body[1].name);
             done();
           });
       });
@@ -3233,7 +3234,7 @@ describe('SDK-to-MockApp', function () {
                 // Assert
                 expect(spyApp.validatePage).toHaveBeenCalled(); //.toHaveBeenCalledWith(page1);
                 expect(spyApp.getVisuals).toHaveBeenCalled();
-                expect(visuals).toEqual(testData.visuals);
+                expect(visuals[0].name).toEqual(testData.visuals[0].name);
                 done();
               });
           });

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -1728,10 +1728,13 @@ describe('SDK-to-HPM', function () {
           loadConfiguration: {
             id: 'fakeId',
             accessToken: 'fakeToken'
+          },
+          response: {
+            body: null
           }
         };
 
-        spyHpm.post.and.returnValue(Promise.resolve(null));
+        spyHpm.post.and.returnValue(Promise.resolve(testData.response));
 
         // Act
         report.load(testData.loadConfiguration);
@@ -1772,10 +1775,13 @@ describe('SDK-to-HPM', function () {
           loadConfiguration: {
             id: 'fakeId',
             accessToken: 'fakeToken'
+          },
+          response: {
+            body: null
           }
         };
 
-        spyHpm.post.and.returnValue(Promise.resolve(null));
+        spyHpm.post.and.returnValue(Promise.resolve(testData.response));
 
         // Act
         report.load(testData.loadConfiguration)
@@ -1791,6 +1797,17 @@ describe('SDK-to-HPM', function () {
     describe('pages', function () {
       it('report.getPages() sends GET /report/pages', function () {
         // Arrange
+        const testData = {
+          response: {
+            body: [
+              {
+                name: 'page1'
+              }
+            ]
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.resolve(testData.response));
 
         // Act
         report.getPages();
@@ -1854,11 +1871,15 @@ describe('SDK-to-HPM', function () {
       it('report.getFilters() sends GET /report/filters', function () {
         // Arrange
         const testData = {
-          filters: [
+          response: {
+            body: [
               (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
               (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
-          ]
+            ]
+          }
         };
+
+        spyHpm.get.and.returnValue(Promise.resolve(testData.response));
 
         // Act
         report.getFilters();
@@ -2134,8 +2155,13 @@ describe('SDK-to-HPM', function () {
           filters: [
               (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
               (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
-          ]
+          ],
+          response: {
+            body: []
+          }
         };
+
+        spyHpm.put.and.returnValue(Promise.resolve(testData.response));
 
         // Act
         page1.setFilters(testData.filters);
@@ -2290,7 +2316,17 @@ describe('SDK-to-HPM', function () {
     describe('visuals', function () {
       it('page.getVisuals() sends GET /report/xyz/pages/uvw/visuals', function () {
         // Arrange
-        spyHpm.get.and.returnValue(Promise.resolve(null));
+        const testData = {
+          response: {
+            body: [
+              {
+                name: 'visual1'
+              }
+            ]
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.resolve(testData.response));
 
         // Act
         page1.getVisuals();
@@ -2825,7 +2861,7 @@ describe('SDK-to-MockApp', function () {
                 // Assert
                 expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.loadConfig);
                 expect(spyApp.load).not.toHaveBeenCalled();
-                expect(errors).toEqual(jasmine.objectContaining(testData.expectedErrors));
+                expect(errors).toEqual(testData.expectedErrors);
                 done();
               });
           });
@@ -2837,12 +2873,7 @@ describe('SDK-to-MockApp', function () {
           loadConfig: {
             id: 'fakeReportId',
             accessToken: 'fakeAccessToken'
-          },
-          expectedErrors: [
-            {
-              message: 'invalid load config'
-            }
-          ]
+          }
         };
 
         iframeLoaded
@@ -2855,6 +2886,7 @@ describe('SDK-to-MockApp', function () {
                 // Assert
                 expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.loadConfig);
                 expect(spyApp.load).toHaveBeenCalledWith(testData.loadConfig);
+                expect(response).toEqual(undefined);
                 done();
               });
           });
@@ -3255,8 +3287,8 @@ describe('SDK-to-MockApp', function () {
         // Act
         iframeLoaded
           .then(() => {
-            spyApp.validatePage.and.returnValue(Promise.resolve(undefined));
-            spyApp.setPage.and.returnValue(Promise.reject(testData.errors));
+            spyApp.validatePage.and.returnValue(Promise.reject(testData.errors));
+
             // Act
             page1.setActive()
               .catch(errors => {
@@ -3283,6 +3315,7 @@ describe('SDK-to-MockApp', function () {
         iframeLoaded
           .then(() => {
             setTimeout(() => {
+              spyApp.validatePage.and.returnValue(Promise.resolve(null));
               spyApp.setPage.and.returnValue(Promise.resolve(null));
               // Act
               page1.setActive()

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -1,6 +1,8 @@
 import * as service from '../src/service';
 import * as embed from '../src/embed';
 import * as report from '../src/report';
+import * as page from '../src/page';
+import * as visual from '../src/visual';
 import * as Wpmp from 'window-post-message-proxy';
 import * as Hpm from 'http-post-message';
 import * as Router from 'powerbi-router';
@@ -584,7 +586,7 @@ describe('Protocol', function () {
       res.send(202);
     });
 
-    router.post('/reports/:uniqueId/visuals/:visualId/events/:eventName', (req, res) => {
+    router.post('/reports/:uniqueId/pages/:pageName/visuals/:visualId/events/:eventName', (req, res) => {
       handler.handle(req);
       res.send(202);
     });
@@ -1016,7 +1018,6 @@ describe('Protocol', function () {
     });
 
     describe('filters (report level)', function () {
-
       it('GET /report/filters returns 200 with body as array of filters', function (done) {
         // Arrange
         const testData = {
@@ -1074,99 +1075,14 @@ describe('Protocol', function () {
           });
       });
 
-      it('POST /report/filters returns 400 if request is invalid', function (done) {
-        // Arrange
-        const testData = {
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.reject(null));
-
-            // Act
-            hpm.post<models.IError>('/report/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/filters returns 202 if request is valid', function (done) {
-        // Arrange
-        const testData = {
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.post<void>('/report/filters', testData.filter)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter);
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                spyApp.addFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/filters will cause POST /reports/:uniqueId/events/filterAdded', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-        const expectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/filterAdded`
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.post<void>('/report/filters', testData.filter, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter);
-                expect(response.statusCode).toEqual(202);
-                expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(expectedEvent));
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                spyApp.addFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
       it('PUT /report/filters returns 400 if request is invalid', function (done) {
         // Arrange
         const testData = {
-          filter: {
-            name: "fakeFilter"
-          }
+          filters: [
+            {
+              name: "fakeFilter"
+            }
+          ]
         };
 
         iframeLoaded
@@ -1174,11 +1090,11 @@ describe('Protocol', function () {
             spyApp.validateFilter.and.returnValue(Promise.reject(null));
 
             // Act
-            hpm.put<models.IError>('/report/filters', testData.filter)
+            hpm.put<models.IError>('/report/filters', testData.filters)
               .catch(response => {
                 // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).not.toHaveBeenCalled();
+                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filters[0]);
+                expect(spyApp.setFilters).not.toHaveBeenCalled();
                 expect(response.statusCode).toEqual(400);
                 // Cleanup
                 spyApp.validateFilter.calls.reset();
@@ -1190,217 +1106,46 @@ describe('Protocol', function () {
       it('PUT /report/filters returns 202 if request is valid', function (done) {
         // Arrange
         const testData = {
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.put<void>('/report/filters', testData.filter)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                spyApp.updateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('PUT /report/filters will cause POST /reports/:uniqueId/events/filterUpdated', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/filterUpdated`
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.put<void>('/report/filters', testData.filter, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(response.statusCode).toEqual(202);
-                expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                spyApp.updateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/allfilters returns 202 if request is valid', function (done) {
-        // Arrange
-        iframeLoaded
-          .then(() => {
-            // Act
-            hpm.delete<void>('/report/allfilters', null)
-              .then(response => {
-                // Assert
-                expect(spyApp.clearFilters).toHaveBeenCalled();
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.clearFilters.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/allfilters causes POST /reports/:uniqueId/events/filtersCleared', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/filtersCleared`
-        };
-
-        iframeLoaded
-          .then(() => {
-
-            // Act
-            hpm.delete<void>('/report/allfilters', null, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                setTimeout(() => {
-                  expect(spyApp.clearFilters).toHaveBeenCalled();
-                  expect(response.statusCode).toEqual(202);
-                  expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                  // Cleanup
-                  spyApp.clearFilters.calls.reset();
-                  done();
-                })
-              });
-          });
-      });
-
-      it('DELETE /report/allfilters causes POST /reports/:uniqueId/events/error', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          error: {
-            message: "error"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/error`,
-          body: testData.error
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.clearFilters.and.returnValue(Promise.reject(testData.error));
-
-            // Act
-            hpm.delete<void>('/report/allfilters', null, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                setTimeout(() => {
-                  expect(spyApp.clearFilters).toHaveBeenCalled();
-                  expect(response.statusCode).toEqual(202);
-                  expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                  // Cleanup
-                  spyApp.clearFilters.calls.reset();
-                  done();
-                })
-              });
-          });
-      });
-
-      it('DELETE /report/filters returns 400 if request is invalid', function (done) {
-        // Arrange
-        const testData = {
-          filter: {
-            name: "fakeFilter"
-          },
-          expectedErrors: [
+          filters: [
             {
-              message: 'invalid filter'
+              name: "fakeFilter"
             }
           ]
         };
 
         iframeLoaded
           .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedErrors));
-
-            // Act
-            hpm.delete<models.IError[]>('/report/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.removeFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/filters returns 202 if request is valid', function (done) {
-        // Arrange
-        const testData = {
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
             spyApp.validateFilter.and.returnValue(Promise.resolve(null));
 
             // Act
-            hpm.delete<void>('/report/filters', testData.filter)
+            hpm.put<void>('/report/filters', testData.filters)
               .then(response => {
                 // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter);
+                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filters[0]);
+                expect(spyApp.setFilters).toHaveBeenCalledWith(testData.filters);
                 expect(response.statusCode).toEqual(202);
                 // Cleanup
                 spyApp.validateFilter.calls.reset();
-                spyApp.removeFilter.calls.reset();
+                spyApp.setFilters.calls.reset();
                 done();
               });
           });
       });
 
-      it('DELETE /report/filters will cause POST /reports/:uniqueId/events/filterRemoved', function (done) {
+      it('PUT /report/filters will cause POST /reports/:uniqueId/events/filtersApplied', function (done) {
         // Arrange
         const testData = {
           uniqueId: 'uniqueId',
           reportId: 'fakeReportId',
-          filter: {
-            name: "fakeFilter"
-          }
+          filters: [
+            {
+              name: "fakeFilter"
+            }
+          ]
         };
         const testExpectedEvent = {
           method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/filterRemoved`
+          url: `/reports/${testData.uniqueId}/events/filtersApplied`
         };
 
         iframeLoaded
@@ -1408,69 +1153,26 @@ describe('Protocol', function () {
             spyApp.validateFilter.and.returnValue(Promise.resolve(null));
 
             // Act
-            hpm.delete<void>('/report/filters', testData.filter, { uid: testData.uniqueId })
+            hpm.put<void>('/report/filters', testData.filters, { uid: testData.uniqueId })
               .then(response => {
                 // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter);
+                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filters[0]);
+                expect(spyApp.setFilters).toHaveBeenCalledWith(testData.filters);
                 expect(response.statusCode).toEqual(202);
                 expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
                 // Cleanup
                 spyApp.validateFilter.calls.reset();
-                spyApp.removeFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/filters will cause POST /reports/:uniqueId/events/filterRemoved', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          filter: {
-            name: "fakeFilter"
-          },
-          error: {
-            message: 'error'
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/error`,
-          body: testData.error
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-            spyApp.removeFilter.and.returnValue(Promise.reject(testData.error));
-
-            // Act
-            hpm.delete<void>('/report/filters', testData.filter, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter);
-                expect(response.statusCode).toEqual(202);
-                expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                spyApp.removeFilter.calls.reset();
+                spyApp.setFilters.calls.reset();
                 done();
               });
           });
       });
     });
-
+    
     describe('filters (page level)', function () {
       it('GET /report/pages/xyz/filters returns 200 with body as array of filters', function (done) {
         // Arrange
         const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
           filters: [
             {
               name: "fakeFilter1"
@@ -1489,7 +1191,7 @@ describe('Protocol', function () {
             hpm.get<models.IFilter[]>('/report/pages/xyz/filters')
               .then(response => {
                 // Assert
-                expect(spyApp.getFilters).toHaveBeenCalledWith(testData.expectedTarget);
+                expect(spyApp.getFilters).toHaveBeenCalled();
                 expect(response.statusCode).toEqual(200);
                 expect(response.body).toEqual(testData.filters);
                 // Cleanup
@@ -1502,12 +1204,8 @@ describe('Protocol', function () {
       it('GET /report/pages/xyz/filters returns 500 with body as error', function (done) {
         // Arrange
         const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
           error: {
-            message: "error"
+            message: "internal error"
           }
         };
 
@@ -1519,7 +1217,7 @@ describe('Protocol', function () {
             hpm.get<models.IFilter[]>('/report/pages/xyz/filters')
               .catch(response => {
                 // Assert
-                expect(spyApp.getFilters).toHaveBeenCalledWith(testData.expectedTarget);
+                expect(spyApp.getFilters).toHaveBeenCalled();
                 expect(response.statusCode).toEqual(500);
                 expect(response.body).toEqual(testData.error);
                 // Cleanup
@@ -1529,224 +1227,28 @@ describe('Protocol', function () {
           });
       });
 
-      it('POST /report/pages/xyz/filters returns 400 if page name is invalid', function (done) {
+      it('PUT /report/pages/xyz/filters returns 400 if request is invalid', function (done) {
         // Arrange
         const testData = {
-          expectedErrors: [
+          filters: [
             {
-              message: "Page does not exist"
+              name: "fakeFilter"
             }
-          ],
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
+          ]
         };
 
         iframeLoaded
           .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedErrors));
             spyApp.validateFilter.and.returnValue(Promise.reject(null));
 
             // Act
-            hpm.post<models.IError[]>('/report/pages/xyz/filters', testData.filter)
+            hpm.put<models.IError>('/report/pages/xyz/filters', testData.filters)
               .catch(response => {
                 // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).not.toHaveBeenCalled();
-                expect(spyApp.addFilter).not.toHaveBeenCalled();
+                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filters[0]);
+                expect(spyApp.setFilters).not.toHaveBeenCalled();
                 expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
                 // Cleanup
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/pages/xyz/filters returns 400 if filter is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          expectedFilterError: {
-            message: "filter is invalid"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedFilterError));
-
-            // Act
-            hpm.post<models.IError[]>('/report/pages/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedFilterError);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/pages/xyz/filters returns 202 if request is valid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.post<void>('/report/pages/xyz/filters', testData.filter)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                spyApp.addFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/pages/xyz/filters will cause POST /reports/:uniqueId/pages/xyz/events/filterAdded', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/pages/xyz/events/filterAdded`
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.post<void>('/report/pages/xyz/filters', testData.filter, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                spyApp.addFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('PUT /report/pages/xyz/filters returns 400 if page name is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          expectedErrors: [
-            {
-              message: "Page does not exist"
-            }
-          ],
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedErrors));
-
-            // Act
-            hpm.put<models.IError[]>('/report/pages/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).not.toHaveBeenCalled();
-                expect(spyApp.updateFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('PUT /report/pages/xyz/filters returns 400 if filter is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          expectedFilterError: {
-            message: "Filter is invalid"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedFilterError));
-
-            // Act
-            hpm.put<models.IError[]>('/report/pages/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedFilterError);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
                 spyApp.validateFilter.calls.reset();
                 done();
               });
@@ -1756,967 +1258,65 @@ describe('Protocol', function () {
       it('PUT /report/pages/xyz/filters returns 202 if request is valid', function (done) {
         // Arrange
         const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.put<void>('/report/pages/xyz/filters', testData.filter)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                spyApp.updateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('PUT /report/pages/xyz/filters will cause POST /reports/:uniqueId/pages/xyz/events/filterUpdated', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/pages/xyz/events/filterUpdated`
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.put<void>('/report/pages/xyz/filters', testData.filter, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                spyApp.updateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      /**
-       * TODO: Sending targeted removal of filter should use DELETE as http method, but if conforming to REST
-       * design DELETE reqeusts should specify filter identity within URL which cannot be done with current filter spec unless they each have unique id.
-       * 
-       * The workaround is to either allow a body to be specified with DELETE requests, or to change to a PUT/POST request
-       */
-      it('DELETE /report/pages/xyz/filters returns 400 if target is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          expectedErrors: [
-            {
-              message: "Page does not exist"
-            }
-          ],
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedErrors));
-
-            // Act
-            hpm.delete<models.IError[]>('/report/pages/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).not.toHaveBeenCalled();
-                expect(spyApp.removeFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/pages/xyz/filters returns 400 if filter is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          expectedFilterError: {
-            message: "Filter is invalid"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedFilterError));
-
-            // Act
-            hpm.delete<models.IError[]>('/report/pages/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.removeFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedFilterError);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/pages/xyz/filters returns 202 if request is valid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.delete<void>('/report/pages/xyz/filters', testData.filter)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                spyApp.removeFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/pages/xyz/filters will cause POST /reports/:uniqueId/pages/xyz/events/filterRemoved', function (done) {
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/pages/xyz/events/filterRemoved`
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.delete<void>('/report/pages/xyz/filters', testData.filter, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                expect(response.body).toBeUndefined();
-
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/pages/xyz/allfilters returns 400 if target is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          expectedErrors: [
-            {
-              message: "Page does not exist"
-            }
-          ]
-        };
-
-        // TODO: REMOVE, and fix root issue of this being called by previous test
-        spyApp.clearFilters.calls.reset();
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedErrors));
-
-            // Act
-            hpm.delete<models.IError[]>('/report/pages/xyz/allfilters')
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.clearFilters).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/pages/xyz/allfilters returns 202 if target is valid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          expectedErrors: [
-            {
-              message: "Page does not exist"
-            }
-          ]
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.delete<models.IError[]>(`/report/pages/${testData.expectedTarget.name}/allfilters`)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.clearFilters).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.clearFilters.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/pages/xyz/allfilters causes POST /reports/:uniqueId/pages/:pageName/events/filtersCleared', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/pages/${testData.expectedTarget.name}/events/filtersCleared`
-        };
-
-        iframeLoaded
-          .then(() => {
-
-            spyApp.clearFilters.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.delete<void>(`/report/pages/${testData.expectedTarget.name}/allfilters`, null, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                setTimeout(() => {
-                  expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                  expect(spyApp.clearFilters).toHaveBeenCalledWith(testData.expectedTarget);
-                  expect(response.statusCode).toEqual(202);
-                  expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                  // Cleanup
-                  spyApp.validateTarget.calls.reset();
-                  spyApp.clearFilters.calls.reset();
-                  done();
-                })
-              });
-          });
-      });
-
-      it('DELETE /report/pages/xyz/allfilters causes POST /reports/:uniqueId/events/error', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "page",
-            name: "xyz"
-          },
-          error: {
-            message: "error"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/error`,
-          body: testData.error
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.clearFilters.and.returnValue(Promise.reject(testData.error))
-
-            // Act
-            hpm.delete<void>(`/report/pages/${testData.expectedTarget.name}/allfilters`, null, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                setTimeout(() => {
-                  expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                  expect(spyApp.clearFilters).toHaveBeenCalledWith(testData.expectedTarget);
-                  expect(response.statusCode).toEqual(202);
-                  expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                  // Cleanup
-                  spyApp.validateTarget.calls.reset();
-                  spyApp.clearFilters.calls.reset();
-                  done();
-                })
-              });
-          });
-      });
-    });
-
-    describe('filters (visual level)', function () {
-      it('GET /report/visuals/xyz/filters returns 200 with body as array of filters', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
           filters: [
             {
-              name: "fakeFilter1"
-            },
+              name: "fakeFilter"
+            }
+          ],
+        };
+
+        iframeLoaded
+          .then(() => {
+            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
+
+            // Act
+            hpm.put<void>('/report/pages/xyz/filters', testData.filters)
+              .then(response => {
+                // Assert
+                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filters[0]);
+                expect(spyApp.setFilters).toHaveBeenCalledWith(testData.filters);
+                expect(response.statusCode).toEqual(202);
+                // Cleanup
+                spyApp.validateFilter.calls.reset();
+                spyApp.setFilters.calls.reset();
+                done();
+              });
+          });
+      });
+
+      it('PUT /report/pages/xyz/filters will cause POST /reports/:uniqueId/pages/xyz/events/filtersApplied', function (done) {
+        // Arrange
+        const testData = {
+          uniqueId: 'uniqueId',
+          reportId: 'fakeReportId',
+          filters: [
             {
-              name: "fakeFilter2"
+              name: "fakeFilter"
             }
           ]
         };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.getFilters.and.returnValue(Promise.resolve(testData.filters));
-
-            // Act
-            hpm.get('/report/visuals/xyz/filters')
-              .then(response => {
-                // Assert
-                expect(spyApp.getFilters).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(response.statusCode).toEqual(200);
-                expect(response.body).toEqual(testData.filters);
-                // Cleanup
-                spyApp.getFilters.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/visuals/xyz/filters returns 400 if visual id is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedErrors: [
-            {
-              message: "visual does not exist"
-            }
-          ],
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedErrors));
-            spyApp.validateFilter.and.returnValue(Promise.reject(null));
-
-            // Act
-            hpm.post<models.IError[]>('/report/visuals/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                // TODO: Seems to be race condition where validateFilter is called by another tst by the time this assertion is executed.
-                //expect(spyApp.validateFilter).not.toHaveBeenCalled();
-                expect(spyApp.addFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
-                // Cleanup
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/visuals/xyz/filters returns 400 if filter is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          expectedFilterError: {
-            message: "filter is invalid"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedFilterError));
-
-            // Act
-            hpm.post<models.IError[]>('/report/visuals/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedFilterError);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/visuals/xyz/filters returns 202 if request is valid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.post<void>('/report/visuals/xyz/filters', testData.filter)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                spyApp.addFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('POST /report/visuals/xyz/filters will cause POST /reports/:uniqueId/visuals/xyz/events/filterAdded', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
         const testExpectedEvent = {
           method: 'POST',
-          url: `/reports/${testData.uniqueId}/visuals/xyz/events/filterAdded`
+          url: `/reports/${testData.uniqueId}/pages/xyz/events/filtersApplied`
         };
 
         iframeLoaded
           .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
+            spyHandler.handle.calls.reset();
             spyApp.validateFilter.and.returnValue(Promise.resolve(null));
 
             // Act
-            hpm.post<void>('/report/visuals/xyz/filters', testData.filter, { uid: testData.uniqueId })
+            hpm.put<void>('/report/pages/xyz/filters', testData.filters, { uid: testData.uniqueId })
               .then(response => {
                 // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                spyApp.addFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('PUT /report/visuals/xyz/filters returns 400 if page name is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          expectedErrors: [
-            {
-              message: "Page does not exist"
-            }
-          ],
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedErrors));
-
-            // Act
-            hpm.put<models.IError[]>('/report/visuals/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).not.toHaveBeenCalled();
-                expect(spyApp.updateFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('PUT /report/visuals/xyz/filters returns 400 if filter is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          expectedFilterError: {
-            message: "Filter is invalid"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedFilterError));
-
-            // Act
-            hpm.put<models.IError[]>('/report/visuals/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedFilterError);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('PUT /report/visuals/xyz/filters returns 202 if request is valid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.put<void>('/report/visuals/xyz/filters', testData.filter)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                spyApp.updateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('PUT /report/visuals/xyz/filters will cause POST /reports/:uniqueId/visuals/xyz/events/filterUpdated', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          },
-          
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/visuals/xyz/events/filterUpdated`
-        };
-        
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.put<void>('/report/visuals/xyz/filters', testData.filter, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
+                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filters[0]);
+                expect(spyApp.setFilters).toHaveBeenCalledWith(testData.filters);
                 expect(response.statusCode).toEqual(202);
                 expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
                 // Cleanup
                 spyApp.validateFilter.calls.reset();
-                spyApp.updateFilter.calls.reset();
+                spyApp.setFilters.calls.reset();
                 done();
-              });
-          });
-      });
-
-      /**
-       * TODO: Sending targeted removal of filter should use DELETE as http method, but if conforming to REST
-       * design DELETE reqeusts should specify filter identity within URL which cannot be done with current filter spec unless they each have unique id.
-       * 
-       * The workaround is to either allow a body to be specified with DELETE requests, or to change to a PUT/POST request
-       */
-      it('DELETE /report/visuals/xyz/filters returns 400 if target is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          expectedErrors: [
-            {
-              message: "Page does not exist"
-            }
-          ],
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedErrors));
-
-            // Act
-            hpm.delete<models.IError[]>('/report/visuals/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).not.toHaveBeenCalled();
-                //expect(spyApp.removeFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/visuals/xyz/filters returns 400 if filter is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          expectedFilterError: {
-            message: "Filter is invalid"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedFilterError));
-
-            // Act
-            hpm.delete<models.IError[]>('/report/visuals/xyz/filters', testData.filter)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                //expect(spyApp.removeFilter).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedFilterError);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/visuals/xyz/filters returns 202 if request is valid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          filter: {
-            name: "fakeFilter"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-            spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.delete<void>('/report/visuals/xyz/filters', testData.filter)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-                expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter, testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.validateFilter.calls.reset();
-                spyApp.removeFilter.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/visuals/xyz/allfilters returns 400 if target is invalid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          expectedErrors: [
-            {
-              message: "visual not exist"
-            }
-          ]
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedErrors));
-
-            // Act
-            hpm.delete<models.IError[]>(`/report/visuals/${testData.expectedTarget.id}/allfilters`)
-              .catch(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.clearFilters).not.toHaveBeenCalled();
-                expect(response.statusCode).toEqual(400);
-                expect(response.body).toEqual(testData.expectedErrors);
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/visuals/xyz/allfilters returns 202 if target is valid', function (done) {
-        // Arrange
-        const testData = {
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          },
-          expectedErrors: [
-            {
-              message: "visual does not exist"
-            }
-          ]
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.delete<models.IError[]>(`/report/visuals/${testData.expectedTarget.id}/allfilters`)
-              .then(response => {
-                // Assert
-                expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(spyApp.clearFilters).toHaveBeenCalledWith(testData.expectedTarget);
-                expect(response.statusCode).toEqual(202);
-
-                // Cleanup
-                spyApp.validateTarget.calls.reset();
-                spyApp.clearFilters.calls.reset();
-                done();
-              });
-          });
-      });
-
-      it('DELETE /report/visuals/xyz/allfilters causes POST /reports/:uniqueId/visuals/:visualId/events/filtersCleared', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/visuals/${testData.expectedTarget.id}/events/filtersCleared`
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.clearFilters.and.returnValue(Promise.resolve(null));
-
-            // Act
-            hpm.delete<void>(`/report/visuals/${testData.expectedTarget.id}/allfilters`, null, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                setTimeout(() => {
-                  expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                  expect(spyApp.clearFilters).toHaveBeenCalledWith(testData.expectedTarget);
-                  expect(response.statusCode).toEqual(202);
-                  expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                  // Cleanup
-                  spyApp.validateTarget.calls.reset();
-                  spyApp.clearFilters.calls.reset();
-                  done();
-                })
-              });
-          });
-      });
-
-      it('DELETE /report/visuals/xyz/allfilters causes POST /reports/:uniqueId/events/error', function (done) {
-        // Arrange
-        const testData = {
-          uniqueId: 'uniqueId',
-          reportId: 'fakeReportId',
-          expectedTarget: {
-            type: "visual",
-            id: "xyz"
-          }
-        };
-        const testExpectedEvent = {
-          method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/error`,
-          body: {
-            message: "error"
-          }
-        };
-
-        iframeLoaded
-          .then(() => {
-            spyApp.clearFilters.and.returnValue(Promise.reject(testExpectedEvent.body))
-
-            // Act
-            hpm.delete<void>(`/report/visuals/${testData.expectedTarget.id}/allfilters`, null, { uid: testData.uniqueId })
-              .then(response => {
-                // Assert
-                setTimeout(() => {
-                  expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.expectedTarget);
-                  expect(spyApp.clearFilters).toHaveBeenCalledWith(testData.expectedTarget);
-                  expect(response.statusCode).toEqual(202);
-                  expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
-                  // Cleanup
-                  spyApp.validateTarget.calls.reset();
-                  spyApp.clearFilters.calls.reset();
-                  done();
-                })
               });
           });
       });
@@ -2865,21 +1465,23 @@ describe('Protocol', function () {
     });
 
     describe('filters (report level)', function () {
-      it('POST /reports/:uniqueId/events/filterAdded when user adds filter', function (done) {
+      it('POST /reports/:uniqueId/events/filtersApplied when user changes filter', function (done) {
         // Arrange
         const testData = {
           uniqueId: 'uniqueId',
           reportId: 'fakeReportId',
           event: {
             initiator: 'user',
-            filter: {
-              name: "fakeFilter"
-            }
+            filters: [
+              {
+                name: "fakeFilter"
+              }
+            ]
           }
         };
         const testExpectedRequest = {
           method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/filterAdded`,
+          url: `/reports/${testData.uniqueId}/events/filtersApplied`,
           body: testData.event
         };
 
@@ -2899,22 +1501,26 @@ describe('Protocol', function () {
             // Cleanup
           });
       });
+    });
 
-      it('POST /reports/:uniqueId/events/filterUpdated when user changes filter', function (done) {
+    describe('filters (page level)', function () {
+      it('POST /reports/:uniqueId/pages/xyz/events/filtersApplied when user changes filter', function (done) {
         // Arrange
         const testData = {
           uniqueId: 'uniqueId',
           reportId: 'fakeReportId',
           event: {
             initiator: 'user',
-            filter: {
-              name: "fakeFilter"
-            }
+            filters: [
+              {
+                name: "fakeFilter"
+              }
+            ]
           }
         };
         const testExpectedRequest = {
           method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/filterUpdated`,
+          url: `/reports/${testData.uniqueId}/pages/xyz/events/filtersApplied`,
           body: testData.event
         };
 
@@ -2934,22 +1540,26 @@ describe('Protocol', function () {
             // Cleanup
           });
       });
+    });
 
-      it('POST /reports/:uniqueId/events/filterRemoved when user removes filter', function (done) {
+    describe('filters (visual level)', function () {
+      it('POST /reports/:uniqueId/pages/xyz/visuals/uvw/events/filtersApplied when user changes filter', function (done) {
         // Arrange
         const testData = {
           uniqueId: 'uniqueId',
           reportId: 'fakeReportId',
           event: {
             initiator: 'user',
-            filter: {
-              name: "fakeFilter"
-            }
+            filters: [
+              {
+                name: "fakeFilter"
+              }
+            ]
           }
         };
         const testExpectedRequest = {
           method: 'POST',
-          url: `/reports/${testData.uniqueId}/events/filterRemoved`,
+          url: `/reports/${testData.uniqueId}/pages/xyz/visuals/uvw/events/filtersApplied`,
           body: testData.event
         };
 
@@ -3051,6 +1661,8 @@ describe('SDK-to-HPM', function () {
   let iframe: HTMLIFrameElement;
   let powerbi: service.Service;
   let report: report.Report;
+  let page1: page.Page;
+  let visual1: visual.Visual;
   let uniqueId = 'uniqueId';
   let embedConfiguration: embed.IEmbedConfiguration;
 
@@ -3079,6 +1691,8 @@ describe('SDK-to-HPM', function () {
       embedUrl: iframeSrc
     };
     report = <report.Report>powerbi.embed($element[0], embedConfiguration);
+    page1 = new page.Page(report, 'xyz');
+    visual1 = new visual.Visual(page1, 'uvw');
     uniqueId = report.config.uniqueId;
 
     iframe = <HTMLIFrameElement>$element.find('iframe')[0];
@@ -3107,921 +1721,784 @@ describe('SDK-to-HPM', function () {
     spyRouter.delete.calls.reset();
   });
 
-  describe('load', function () {
-    it('report.load() sends POST /report/load with configuration in body', function () {
-      // Arrange
-      const testData = {
-        loadConfiguration: {
-          id: 'fakeId',
-          accessToken: 'fakeToken'
-        }
-      };
-
-      spyHpm.post.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.load(testData.loadConfiguration);
-
-      // Assert
-      expect(spyHpm.post).toHaveBeenCalledWith('/report/load', testData.loadConfiguration, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.load() returns promise that rejects with validation error if the load configuration is invalid', function (done) {
-      // Arrange
-      const testData = {
-        loadConfiguration: {
-          id: 'fakeId',
-          accessToken: 'fakeToken'
-        },
-        errorResponse: {
-          body: {
-            message: "invalid configuration object"
+  describe('report', function () {
+    describe('load', function () {
+      it('report.load() sends POST /report/load with configuration in body', function () {
+        // Arrange
+        const testData = {
+          loadConfiguration: {
+            id: 'fakeId',
+            accessToken: 'fakeToken'
           }
-        }
-      };
+        };
 
-      spyHpm.post.and.returnValue(Promise.reject(testData.errorResponse));
+        spyHpm.post.and.returnValue(Promise.resolve(null));
 
-      // Act
-      report.load(testData.loadConfiguration)
-        .catch(error => {
-          expect(spyHpm.post).toHaveBeenCalledWith('/report/load', testData.loadConfiguration, { uid: uniqueId }, iframe.contentWindow);
-          expect(error).toEqual(testData.errorResponse.body);
-          // Assert
-          done();
-        });
-    });
+        // Act
+        report.load(testData.loadConfiguration);
 
-    it('report.load() returns promise that resolves with null if the report load successful', function (done) {
-      // Arrange
-      const testData = {
-        loadConfiguration: {
-          id: 'fakeId',
-          accessToken: 'fakeToken'
-        }
-      };
+        // Assert
+        expect(spyHpm.post).toHaveBeenCalledWith('/report/load', testData.loadConfiguration, { uid: uniqueId }, iframe.contentWindow);
+      });
 
-      spyHpm.post.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.load(testData.loadConfiguration)
-        .then(response => {
-          expect(spyHpm.post).toHaveBeenCalledWith('/report/load', testData.loadConfiguration, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          // Assert
-          done();
-        });
-    });
-  });
-
-  describe('pages', function () {
-    it('report.getPages() sends GET /report/pages', function () {
-      // Arrange
-
-      // Act
-      report.getPages();
-
-      // Assert
-      expect(spyHpm.get).toHaveBeenCalledWith('/report/pages', { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.getPages() return promise that rejects with server error if there was error getting pages', function (done) {
-      // Arrange
-      const testData = {
-        expectedError: {
-          body: {
-            message: 'internal server error'
+      it('report.load() returns promise that rejects with validation error if the load configuration is invalid', function (done) {
+        // Arrange
+        const testData = {
+          loadConfiguration: {
+            id: 'fakeId',
+            accessToken: 'fakeToken'
+          },
+          errorResponse: {
+            body: {
+              message: "invalid configuration object"
+            }
           }
-        }
-      };
+        };
 
-      spyHpm.get.and.returnValue(Promise.reject(testData.expectedError));
+        spyHpm.post.and.returnValue(Promise.reject(testData.errorResponse));
 
-      // Act
-      report.getPages()
-        .catch(error => {
-          // Assert
-          expect(spyHpm.get).toHaveBeenCalledWith('/report/pages', { uid: uniqueId }, iframe.contentWindow);
-          expect(error).toEqual(testData.expectedError.body);
-          done();
-        });
+        // Act
+        report.load(testData.loadConfiguration)
+          .catch(error => {
+            expect(spyHpm.post).toHaveBeenCalledWith('/report/load', testData.loadConfiguration, { uid: uniqueId }, iframe.contentWindow);
+            expect(error).toEqual(testData.errorResponse.body);
+            // Assert
+            done();
+          });
+      });
+
+      it('report.load() returns promise that resolves with null if the report load successful', function (done) {
+        // Arrange
+        const testData = {
+          loadConfiguration: {
+            id: 'fakeId',
+            accessToken: 'fakeToken'
+          }
+        };
+
+        spyHpm.post.and.returnValue(Promise.resolve(null));
+
+        // Act
+        report.load(testData.loadConfiguration)
+          .then(response => {
+            expect(spyHpm.post).toHaveBeenCalledWith('/report/load', testData.loadConfiguration, { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            // Assert
+            done();
+          });
+      });
     });
 
-    it('report.getPages() returns promise that resolves with list of page names', function (done) {
-      // Arrange
-      const testData = {
-        expectedResponse: {
-          body: [
+    describe('pages', function () {
+      it('report.getPages() sends GET /report/pages', function () {
+        // Arrange
+
+        // Act
+        report.getPages();
+
+        // Assert
+        expect(spyHpm.get).toHaveBeenCalledWith('/report/pages', { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('report.getPages() return promise that rejects with server error if there was error getting pages', function (done) {
+        // Arrange
+        const testData = {
+          expectedError: {
+            body: {
+              message: 'internal server error'
+            }
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.reject(testData.expectedError));
+
+        // Act
+        report.getPages()
+          .catch(error => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith('/report/pages', { uid: uniqueId }, iframe.contentWindow);
+            expect(error).toEqual(testData.expectedError.body);
+            done();
+          });
+      });
+
+      it('report.getPages() returns promise that resolves with list of Page objects', function (done) {
+        // Arrange
+        const testData = {
+          pages: [
             'page1',
             'page2'
+          ],
+          expectedResponse: {
+            body: [
+              report.page('page1'),
+              report.page('page2')
+            ]
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.resolve(testData.expectedResponse));
+
+        // Act
+        report.getPages()
+          .then(pages => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith('/report/pages', { uid: uniqueId }, iframe.contentWindow);
+            expect(pages[0].name).toEqual(testData.expectedResponse.body[0].name);
+            expect(pages[1].name).toEqual(testData.expectedResponse.body[1].name);
+            done();
+          });
+      });
+    });
+
+    describe('filters', function () {
+      it('report.getFilters() sends GET /report/filters', function () {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
-        }
-      };
+        };
 
-      spyHpm.get.and.returnValue(Promise.resolve(testData.expectedResponse));
+        // Act
+        report.getFilters();
 
-      // Act
-      report.getPages()
-        .then(pages => {
-          // Assert
-          expect(spyHpm.get).toHaveBeenCalledWith('/report/pages', { uid: uniqueId }, iframe.contentWindow);
-          expect(pages).toEqual(testData.expectedResponse.body);
-          done();
-        });
+        // Assert
+        expect(spyHpm.get).toHaveBeenCalledWith('/report/filters', { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('report.getFilters() returns promise that rejects with server error if there was error getting  filters', function (done) {
+        // Arrange
+        const testData = {
+          expectedErrors: {
+            body: [
+              {
+                message: 'target is invalid, missing property x'
+              }
+            ]
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.reject(testData.expectedErrors));
+
+        // Act
+        report.getFilters()
+          .catch(errors => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith('/report/filters', { uid: uniqueId }, iframe.contentWindow);
+            expect(errors).toEqual(testData.expectedErrors.body);
+            done();
+          });
+      });
+
+      it('report.getFilters() returns promise that resolves with the filters if the request is accepted', function (done) {
+        // Arrange
+        const testData = {
+          response: {
+            body: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            ]
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.resolve(testData.response));
+
+        // Act
+        report.getFilters()
+          .then(filters => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith('/report/filters', { uid: uniqueId }, iframe.contentWindow);
+            expect(filters).toEqual(testData.response.body);
+            done();
+          });
+      });
+
+      it('report.setFilters(filters) sends PUT /report/filters', function () {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+          ]
+        };
+
+        // Act
+        report.setFilters(testData.filters);
+
+        // Assert
+        expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', testData.filters, { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('report.setFilters(filters) returns promise that rejects with validation errors if filter is invalid', function (done) {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+          ],
+          expectedErrors: {
+            body: [
+              {
+                message: 'target is invalid, missing property x'
+              }
+            ]
+          }
+        };
+
+        spyHpm.put.and.returnValue(Promise.reject(testData.expectedErrors));
+
+        // Act
+        report.setFilters(testData.filters)
+          .catch(errors => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', testData.filters, { uid: uniqueId }, iframe.contentWindow);
+            expect(errors).toEqual(testData.expectedErrors.body);
+            done();
+          });
+      });
+
+      it('report.setFilters(filters) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+          ]
+        };
+
+        spyHpm.put.and.returnValue(Promise.resolve(null));
+
+        // Act
+        report.setFilters(testData.filters)
+          .then(response => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', testData.filters, { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            done();
+          });
+      });
+
+      it('report.removeFilters() sends PUT /report/filters', function () {
+        // Arrange
+
+        // Act
+        report.removeFilters();
+
+        // Assert
+        expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', [], { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('report.removeFilters() returns promise that resolves with null if request is accepted', function (done) {
+        // Arrange
+        spyHpm.put.and.returnValue(Promise.resolve(null));
+
+        // Act
+        report.removeFilters()
+          .then(response => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', [], { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            done();
+          });
+      });
+    });
+
+    describe('settings', function () {
+      it('report.updateSettings(settings) sends PATCH /report/settings with settings object', function () {
+        // Arrange
+        const testData = {
+          settings: {
+            filterPaneEnabled: false
+          }
+        };
+
+        // Act
+        report.updateSettings(testData.settings);
+
+        // Assert
+        expect(spyHpm.patch).toHaveBeenCalledWith('/report/settings', testData.settings, { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('report.updateSettings(setting) returns promise that rejects with validation error if object is invalid', function (done) {
+        // Arrange
+        const testData = {
+          settings: {
+            filterPaneEnabled: false
+          },
+          expectedError: {
+            body: [
+              {
+                message: 'settings object is invalid'
+              }
+            ]
+          }
+        };
+
+        spyHpm.patch.and.returnValue(Promise.reject(testData.expectedError));
+
+        // Act
+        report.updateSettings(testData.settings)
+          .catch(errors => {
+
+            // Assert
+            expect(spyHpm.patch).toHaveBeenCalledWith('/report/settings', testData.settings, { uid: uniqueId }, iframe.contentWindow);
+            expect(errors).toEqual(testData.expectedError.body);
+            done()
+          });
+      });
+
+      it('report.updateSettings(settings) returns promise that resolves with null if requst is valid and accepted', function (done) {
+        // Arrange
+        const testData = {
+          settings: {
+            filterPaneEnabled: false
+          }
+        };
+
+        spyHpm.patch.and.returnValue(Promise.resolve(null));
+
+        // Act
+        report.updateSettings(testData.settings)
+          .then(response => {
+
+            // Assert
+            expect(spyHpm.patch).toHaveBeenCalledWith('/report/settings', testData.settings, { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            done()
+          });
+      });
     });
   });
 
-  describe('filters (report level)', function () {
-    it('report.addFilter(filter) sends POST /report/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON()
-      };
+  describe('page', function () {
+    describe('filters', function () {
+      it('page.getFilters() sends GET /report/pages/xyz/filters', function () {
+        // Arrange
 
+        // Act
+        page1.getFilters();
 
-      // Act
-      report.addFilter(testData.filter);
+        // Assert
+        expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, { uid: uniqueId }, iframe.contentWindow);
+      });
 
-      // Assert
-      expect(spyHpm.post).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.addFilter(filter) returns promise that rejects with validation errors if filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
+      it('page.getFilters() return promise that rejects with server error if there was error getting filters', function (done) {
+        // Arrange
+        const testData = {
+          expectedError: {
+            body: {
+              message: 'internal server error'
             }
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.reject(testData.expectedError));
+
+        // Act
+        page1.getFilters()
+          .catch(error => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, { uid: uniqueId }, iframe.contentWindow);
+            expect(error).toEqual(testData.expectedError.body);
+            done();
+          });
+      });
+
+      it('page.getFilters() returns promise that resolves with list of filters', function (done) {
+        // Arrange
+        const testData = {
+          expectedResponse: {
+            body: [
+              { x: 'fakeFilter1' },
+              { x: 'fakeFilter2' }
+            ]
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.resolve(testData.expectedResponse));
+
+        // Act
+        page1.getFilters()
+          .then(filters => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, { uid: uniqueId }, iframe.contentWindow);
+            expect(filters).toEqual(testData.expectedResponse.body);
+            done();
+          });
+      });
+
+      it('page.setFilters(filters) sends PUT /report/pages/xyz/filters', function () {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
-        }
-      };
+        };
 
-      spyHpm.post.and.returnValue(Promise.reject(testData.expectedErrors));
+        // Act
+        page1.setFilters(testData.filters);
 
-      // Act
-      report.addFilter(testData.filter)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.post).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
+        // Assert
+        expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, testData.filters, { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('page.setFilters(filters) returns promise that rejects with validation errors if filter is invalid', function (done) {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+          ],
+          expectedErrors: {
+            body: [
+              {
+                message: 'target is invalid, missing property x'
+              }
+            ]
+          }
+        };
+
+        spyHpm.put.and.returnValue(Promise.reject(testData.expectedErrors));
+
+        // Act
+        page1.setFilters(testData.filters)
+          .catch(errors => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, testData.filters, { uid: uniqueId }, iframe.contentWindow);
+            expect(errors).toEqual(testData.expectedErrors.body);
+            done();
+          });
+      });
+
+      it('page.setFilters(filters) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+          ]
+        };
+
+        spyHpm.put.and.returnValue(Promise.resolve(null));
+
+        // Act
+        page1.setFilters(testData.filters)
+          .then(response => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, testData.filters, { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            done();
+          });
+      });
+
+      it('page.removeFilters() sends PUT /report/pages/xyz/filters', function () {
+        // Arrange
+
+        // Act
+        page1.removeFilters();
+
+        // Assert
+        expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, [], { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('page.removeFilters() returns promise that resolves with null if request is accepted', function (done) {
+        // Arrange
+        spyHpm.put.and.returnValue(Promise.resolve(null));
+
+        // Act
+        page1.removeFilters()
+          .then(response => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, [], { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            done();
+          });
+      });
     });
 
-    it('report.addFilter(filter) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON()
-      };
+    describe('setActive', function () {
+      it('page.setActive() sends PUT /report/pages/active', function () {
+        // Arrange
+        const testData = {
+          page: {
+            name: page1.name,
+            displayName: null
+          }
+        };
 
-      spyHpm.post.and.returnValue(Promise.resolve(null));
+        spyHpm.put.and.returnValue(Promise.resolve(null));
 
-      // Act
-      report.addFilter(testData.filter)
-        .then(response => {
-          // Assert
-          expect(spyHpm.post).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
+        // Act
+        page1.setActive();
+
+        // Assert
+        expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/active`, testData.page, { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('page.setActive() returns a promise rejected with errors if the page was invalid', function (done) {
+        // Arrange
+        const testData = {
+          page: {
+            name: page1.name,
+            displayName: null
+          },
+          response: {
+            body: [
+              {
+                message: 'page abc123 does not exist on report xyz'
+              }
+            ]
+          }
+        };
+
+        spyHpm.put.and.returnValue(Promise.reject(testData.response));
+
+        // Act
+        page1.setActive()
+          .catch(errors => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/active`, testData.page, { uid: uniqueId }, iframe.contentWindow);
+            expect(errors).toEqual(testData.response.body);
+            done();
+          });
+      });
+
+      it('page.setActive() returns a promise resolved with null if the page is valid', function (done) {
+        // Arrange
+        const testData = {
+          page: {
+            name: page1.name,
+            displayName: null
+          }
+        };
+
+        spyHpm.put.and.returnValue(Promise.resolve(null));
+
+        // Act
+        page1.setActive()
+          .then(response => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/active`, testData.page, { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            done();
+          });
+      });
     });
 
-    it('report.updateFilter(filter) sends PUT /report/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON()
-      };
+    describe('visuals', function () {
+      it('page.getVisuals() sends GET /report/xyz/pages/uvw/visuals', function () {
+        // Arrange
+        spyHpm.get.and.returnValue(Promise.resolve(null));
 
+        // Act
+        page1.getVisuals();
 
-      // Act
-      report.updateFilter(testData.filter);
+        // Assert
+        expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${page1.name}/visuals`, { uid: uniqueId }, iframe.contentWindow);
+      });
 
-      // Assert
-      expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.updateFilter(filter) returns promise that rejects with validation errors if filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
+      it('page.getVisuals() returns promise rejected with error if server could not retrieve visuals', function (done) {
+        // Arrange
+        const testData = {
+          response: {
+            body: {
+              message: 'could not get visuals'
             }
-          ]
-        }
-      };
+          }
+        };
 
-      spyHpm.put.and.returnValue(Promise.reject(testData.expectedErrors));
+        spyHpm.get.and.returnValue(Promise.reject(testData.response));
 
-      // Act
-      report.updateFilter(testData.filter)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
+        // Act
+        page1.getVisuals()
+          .catch(error => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${page1.name}/visuals`, { uid: uniqueId }, iframe.contentWindow);
+            expect(error).toEqual(testData.response.body);
+            done();
+          });
+      });
 
-    it('report.updateFilter(filter) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON()
-      };
+      it('page.getVisuals() returns promise resolved with visuals if request is successful', function (done) {
+        // Arrange
+        const testData = {
+          response: {
+            body: [
+              {
+                name: 'Visual1'
+              },
+              {
+                name: 'Visual2'
+              }
+            ]
+          }
+        };
 
-      spyHpm.put.and.returnValue(Promise.resolve(null));
+        spyHpm.get.and.returnValue(Promise.resolve(testData.response));
 
-      // Act
-      report.updateFilter(testData.filter)
-        .then(response => {
-          // Assert
-          expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
-
-    it('report.removeFilter(filter) sends DELETE /report/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON()
-      };
-
-
-      // Act
-      report.removeFilter(testData.filter);
-
-      // Assert
-      expect(spyHpm.delete).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.removeFilter(filter) returns promise that rejects with validation errors if filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
-            }
-          ]
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.reject(testData.expectedErrors));
-
-      // Act
-      report.removeFilter(testData.filter)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
-
-    it('report.removeAllFilters() sends DELETE /report/allfilters', function () {
-      // Arrange
-
-      // Act
-      report.removeAllFilters();
-
-      // Assert
-      expect(spyHpm.delete).toHaveBeenCalledWith('/report/allfilters', null, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.removeFilter(filter) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON()
-      };
-
-      spyHpm.delete.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.removeFilter(testData.filter)
-        .then(response => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
+        // Act
+        page1.getVisuals()
+          .then(visuals => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${page1.name}/visuals`, { uid: uniqueId }, iframe.contentWindow);
+            expect(visuals).toEqual(testData.response.body);
+            done();
+          });
+      });
     });
   });
 
-  describe('filters (page level)', function () {
-    it('report.addFilter(filter, target) sends POST /report/pages/:pageName/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
+  describe('visuals', function () {
+    describe('filters', function () {
+      it('visual.getFilters() sends GET /report/pages/xyz/visuals/uvw/filters', function () {
+        // Arrange
 
+        // Act
+        visual1.getFilters();
 
-      // Act
-      report.addFilter(testData.filter, testData.target);
+        // Assert
+        expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, { uid: uniqueId }, iframe.contentWindow);
+      });
 
-      // Assert
-      expect(spyHpm.post).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.addFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        },
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
+      it('visual.getFilters() return promise that rejects with server error if there was error getting filters', function (done) {
+        // Arrange
+        const testData = {
+          expectedError: {
+            body: {
+              message: 'internal server error'
             }
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.reject(testData.expectedError));
+
+        // Act
+        visual1.getFilters()
+          .catch(error => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, { uid: uniqueId }, iframe.contentWindow);
+            expect(error).toEqual(testData.expectedError.body);
+            done();
+          });
+      });
+
+      it('visual.getFilters() returns promise that resolves with list of filters', function (done) {
+        // Arrange
+        const testData = {
+          response: {
+            body: [
+              { x: 'fakeFilter1' },
+              { x: 'fakeFilter2' }
+            ]
+          }
+        };
+
+        spyHpm.get.and.returnValue(Promise.resolve(testData.response));
+
+        // Act
+        visual1.getFilters()
+          .then(filters => {
+            // Assert
+            expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, { uid: uniqueId }, iframe.contentWindow);
+            expect(filters).toEqual(testData.response.body);
+            done();
+          });
+      });
+
+      it('visual.setFilters(filters) sends PUT /report/pages/xyz/visuals/uvw/filters', function () {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
-        }
-      };
+        };
 
-      spyHpm.post.and.returnValue(Promise.reject(testData.expectedErrors));
+        spyHpm.put.and.returnValue(Promise.resolve(null));
 
-      // Act
-      report.addFilter(testData.filter, testData.target)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.post).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
+        // Act
+        visual1.setFilters(testData.filters);
 
-    it('report.addFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
+        // Assert
+        expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, testData.filters, { uid: uniqueId }, iframe.contentWindow);
+      });
 
-      spyHpm.post.and.returnValue(Promise.resolve(null));
+      it('visual.setFilters(filters) returns promise that rejects with validation errors if filter is invalid', function (done) {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+          ],
+          expectedErrors: {
+            body: [
+              {
+                message: 'target is invalid, missing property x'
+              }
+            ]
+          }
+        };
 
-      // Act
-      report.addFilter(testData.filter, testData.target)
-        .then(response => {
-          // Assert
-          expect(spyHpm.post).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
+        spyHpm.put.and.returnValue(Promise.reject(testData.expectedErrors));
 
-    it('report.updateFilter(filter, target) sends PUT /report/pages/:pageName/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
+        // Act
+        visual1.setFilters(testData.filters)
+          .catch(errors => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, testData.filters, { uid: uniqueId }, iframe.contentWindow);
+            expect(errors).toEqual(testData.expectedErrors.body);
+            done();
+          });
+      });
 
-      // Act
-      report.updateFilter(testData.filter, testData.target);
-
-      // Assert
-      expect(spyHpm.put).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.updateFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        },
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
-            }
+      it('visual.setFilters(filters) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
+        // Arrange
+        const testData = {
+          filters: [
+              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
-        }
-      };
-
-      spyHpm.put.and.returnValue(Promise.reject(testData.expectedErrors));
-
-      // Act
-      report.updateFilter(testData.filter, testData.target)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.put).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
-
-    it('report.updateFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
-
-      spyHpm.put.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.updateFilter(testData.filter, testData.target)
-        .then(response => {
-          // Assert
-          expect(spyHpm.put).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
-
-    it('report.removeFilter(filter, target) sends DELETE /report/pages/:pageName/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
-
-
-      // Act
-      report.removeFilter(testData.filter, testData.target);
-
-      // Assert
-      expect(spyHpm.delete).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.removeFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        },
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
-            }
-          ]
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.reject(testData.expectedErrors));
-
-      // Act
-      report.removeFilter(testData.filter, testData.target)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
-
-    it('report.removeFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.removeFilter(testData.filter, testData.target)
-        .then(response => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/pages/page1/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
-
-    it('report.removeAllFilters(target) sends DELETE /report/pages/:pageName/allfilters', function () {
-      // Arrange
-      const testData = {
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
-
-      // Act
-      report.removeAllFilters(testData.target);
-
-      // Assert
-      expect(spyHpm.delete).toHaveBeenCalledWith(`/report/pages/${testData.target.name}/allfilters`, null, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.removeAllFilters(target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        },
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
-            }
-          ]
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.reject(testData.expectedErrors));
-
-      // Act
-      report.removeAllFilters(testData.target)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/pages/page1/allfilters', null, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
-
-    it('report.removeAllFilters(target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.removeAllFilters(testData.target)
-        .then(response => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/pages/page1/allfilters', null, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
-  });
-
-  describe('filters (visual level)', function () {
-    it('report.addFilter(filter, target) sends POST /report/visuals/:visualId/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      // Act
-      report.addFilter(testData.filter, testData.target);
-
-      // Assert
-      expect(spyHpm.post).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.addFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        },
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
-            }
-          ]
-        }
-      };
-
-      spyHpm.post.and.returnValue(Promise.reject(testData.expectedErrors));
-
-      // Act
-      report.addFilter(testData.filter, testData.target)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.post).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
-
-    it('report.addFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      spyHpm.post.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.addFilter(testData.filter, testData.target)
-        .then(response => {
-          // Assert
-          expect(spyHpm.post).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
-
-    it('report.updateFilter(filter, target) sends PUT /report/visuals/:visualId/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      // Act
-      report.updateFilter(testData.filter, testData.target);
-
-      // Assert
-      expect(spyHpm.put).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.updateFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        },
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
-            }
-          ]
-        }
-      };
-
-      spyHpm.put.and.returnValue(Promise.reject(testData.expectedErrors));
-
-      // Act
-      report.updateFilter(testData.filter, testData.target)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.put).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
-
-    it('report.updateFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      spyHpm.put.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.updateFilter(testData.filter, testData.target)
-        .then(response => {
-          // Assert
-          expect(spyHpm.put).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
-
-    it('report.removeFilter(filter, target) sends DELETE /report/visuals/:visualId/filters with filter', function () {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      // Act
-      report.removeFilter(testData.filter, testData.target);
-
-      // Assert
-      expect(spyHpm.delete).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.removeFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        },
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
-            }
-          ]
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.reject(testData.expectedErrors));
-
-      // Act
-      report.removeFilter(testData.filter, testData.target)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
-
-    it('report.removeFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.removeFilter(testData.filter, testData.target)
-        .then(response => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/visuals/visualId/filters', testData.filter, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
-
-    it('report.removeAllFilters(target) sends DELETE /report/visuals/:visualId/allfilters', function () {
-      // Arrange
-      const testData = {
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "fakeId"
-        }
-      };
-
-      // Act
-      report.removeAllFilters(testData.target);
-
-      // Assert
-      expect(spyHpm.delete).toHaveBeenCalledWith(`/report/visuals/${testData.target.id}/allfilters`, null, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.removeAllFilters(target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        },
-        expectedErrors: {
-          body: [
-            {
-              message: 'target is invalid, missing property x'
-            }
-          ]
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.reject(testData.expectedErrors));
-
-      // Act
-      report.removeAllFilters(testData.target)
-        .catch(errors => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/visuals/visualId/allfilters', null, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedErrors.body);
-          done();
-        });
-    });
-
-    it('report.removeAllFilters(target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      spyHpm.delete.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.removeAllFilters(testData.target)
-        .then(response => {
-          // Assert
-          expect(spyHpm.delete).toHaveBeenCalledWith('/report/visuals/visualId/allfilters', null, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done();
-        });
-    });
-  });
-
-  describe('settings', function () {
-    it('report.updateSettings(settings) sends PATCH /report/settings with settings object', function () {
-      // Arrange
-      const testData = {
-        settings: {
-          filterPaneEnabled: false
-        }
-      };
-
-      // Act
-      report.updateSettings(testData.settings);
-
-      // Assert
-      expect(spyHpm.patch).toHaveBeenCalledWith('/report/settings', testData.settings, { uid: uniqueId }, iframe.contentWindow);
-    });
-
-    it('report.updateSettings(setting) returns promise that rejects with validation error if object is invalid', function (done) {
-      // Arrange
-      const testData = {
-        settings: {
-          filterPaneEnabled: false
-        },
-        expectedError: {
-          body: [
-            {
-              message: 'settings object is invalid'
-            }
-          ]
-        }
-      };
-
-      spyHpm.patch.and.returnValue(Promise.reject(testData.expectedError));
-
-      // Act
-      report.updateSettings(testData.settings)
-        .catch(errors => {
-
-          // Assert
-          expect(spyHpm.patch).toHaveBeenCalledWith('/report/settings', testData.settings, { uid: uniqueId }, iframe.contentWindow);
-          expect(errors).toEqual(testData.expectedError.body);
-          done()
-        });
-    });
-
-    it('report.updateSettings(settings) returns promise that resolves with null if requst is valid and accepted', function (done) {
-      // Arrange
-      const testData = {
-        settings: {
-          filterPaneEnabled: false
-        }
-      };
-
-      spyHpm.patch.and.returnValue(Promise.resolve(null));
-
-      // Act
-      report.updateSettings(testData.settings)
-        .then(response => {
-
-          // Assert
-          expect(spyHpm.patch).toHaveBeenCalledWith('/report/settings', testData.settings, { uid: uniqueId }, iframe.contentWindow);
-          expect(response).toEqual(null);
-          done()
-        });
-    });
+        };
+
+        spyHpm.put.and.returnValue(Promise.resolve(null));
+
+        // Act
+        visual1.setFilters(testData.filters)
+          .then(response => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, testData.filters, { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            done();
+          });
+      });
+
+      it('visual.removeFilters() sends PUT /report/pages/xyz/filters', function () {
+        // Arrange
+
+        // Act
+        visual1.removeFilters();
+
+        // Assert
+        expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, [], { uid: uniqueId }, iframe.contentWindow);
+      });
+
+      it('visual.removeFilters() returns promise that resolves with null if request is accepted', function (done) {
+        // Arrange
+        spyHpm.put.and.returnValue(Promise.resolve(null));
+
+        // Act
+        visual1.removeFilters()
+          .then(response => {
+            // Assert
+            expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, [], { uid: uniqueId }, iframe.contentWindow);
+            expect(response).toEqual(null);
+            done();
+          });
+      });
+    });    
   });
 
   describe('SDK-to-Router (Event subscription)', function () {
@@ -4136,12 +2613,12 @@ describe('SDK-to-WPMP', function () {
     it(`off('eventName', handler) will remove single handler which matches function reference for that event`, function () {
       // Arrange
       const testData = {
-        eventName: 'filterAdded',
+        eventName: 'filtersApplied',
         handler: jasmine.createSpy('handler1'),
         simulatedEvent: {
           data: {
             method: 'POST',
-            url: `/reports/${uniqueId}/events/filterAdded`,
+            url: `/reports/${uniqueId}/events/filtersApplied`,
             body: {
               initiator: 'sdk',
               filter: {
@@ -4166,14 +2643,14 @@ describe('SDK-to-WPMP', function () {
     it('if multiple handlers for the same event are registered they will all be called', function () {
       // Arrange
       const testData = {
-        eventName: 'filterAdded',
+        eventName: 'filtersApplied',
         handler: jasmine.createSpy('handler1'),
         handler2: jasmine.createSpy('handler2'),
         handler3: jasmine.createSpy('handler3'),
         simulatedEvent: {
           data: {
             method: 'POST',
-            url: `/reports/${uniqueId}/events/filterAdded`,
+            url: `/reports/${uniqueId}/events/filtersApplied`,
             body: {
               initiator: 'sdk',
               filter: {
@@ -4202,14 +2679,14 @@ describe('SDK-to-WPMP', function () {
     it(`off('eventName') will remove all handlers which matches event name`, function () {
       // Arrange
       const testData = {
-        eventName: 'filterUpdated',
+        eventName: 'filtersApplied',
         handler: jasmine.createSpy('handler1'),
         handler2: jasmine.createSpy('handler2'),
         handler3: jasmine.createSpy('handler3'),
         simulatedEvent: {
           data: {
             method: 'POST',
-            url: '/reports/fakeReportId/events/filterUpdated',
+            url: '/reports/fakeReportId/events/filtersApplied',
             body: {
               initiator: 'sdk',
               filter: {
@@ -4421,514 +2898,73 @@ describe('SDK-to-MockApp', function () {
             .then(pages => {
               // Assert
               expect(spyApp.getPages).toHaveBeenCalled();
-              expect(pages).toEqual(testData.pages);
+              // expect(pages).toEqual(testData.pages);
               done();
             });
         });
     });
   });
 
-  describe('filters (report level)', function () {
-    it('report.addFilter(filter) returns promise that rejects with validation errors if filter is invalid', function (done) {
+  describe('filters', function () {
+    it('report.setFilters(filters) returns promise that rejects with validation errors if filter is invalid', function (done) {
       // Arrange
       const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        expectedError: {
-          message: 'invalid filter'
-        }
+        filters: [
+            (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
+        ],
+        expectedErrors: [
+          {
+            message: 'invalid filter'
+          }
+        ]
       };
 
       iframeLoaded
         .then(() => {
-          spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedError));
+          spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedErrors));
           // Act
-          report.addFilter(testData.filter)
+          report.setFilters(testData.filters)
             .catch(error => {
               // Assert
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.addFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
+              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filters[0]);
+              expect(spyApp.setFilters).not.toHaveBeenCalled();
+              expect(error).toEqual(jasmine.objectContaining(testData.expectedErrors));
               done();
             });
         });
     });
 
-    it('report.addFilter(filter) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
+    it('report.setFilters(filters) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
       // Arrange
       const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
+        filters: [(new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()]
       };
-
+      
       iframeLoaded
         .then(() => {
           spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.addFilter.and.returnValue(Promise.resolve(null));
+          spyApp.setFilters.and.returnValue(Promise.resolve(null));
           // Act
-          report.addFilter(testData.filter)
+          report.setFilters(testData.filters)
             .then(response => {
               // Assert
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter);
+              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filters[0]);
+              expect(spyApp.setFilters).toHaveBeenCalledWith(testData.filters);
               done();
             });
         });
     });
 
-    it('report.updateFilter(filter) returns promise that rejects with validation errors if filter is invalid', function (done) {
+    it('report.removeFilters() returns promise that resolves with null if the request was accepted', function (done) {
       // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        expectedError: {
-          message: 'invalid filter'
-        }
-      };
-
       iframeLoaded
         .then(() => {
-          spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedError));
+          spyApp.setFilters.and.returnValue(Promise.resolve(null));
           // Act
-          report.updateFilter(testData.filter)
-            .catch(error => {
-              // Assert
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.updateFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
-              done();
-            });
-        });
-    });
-
-    it('report.updateFilter(filter) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.updateFilter.and.returnValue(Promise.resolve(null));
-          // Act
-          report.updateFilter(testData.filter)
+          report.removeFilters()
             .then(response => {
               // Assert
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter);
-              done();
-            });
-        });
-    });
-
-    it('report.removeFilter(filter) returns promise that rejects with validation errors if filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        expectedError: {
-          message: 'invalid filter'
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateFilter.and.returnValue(Promise.reject(testData.expectedError));
-          // Act
-          report.removeFilter(testData.filter)
-            .catch(error => {
-              // Assert
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.removeFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
-              done();
-            });
-        });
-    });
-
-    it('report.removeFilter(filter) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.removeFilter.and.returnValue(Promise.resolve(null));
-          // Act
-          report.removeFilter(testData.filter)
-            .then(response => {
-              // Assert
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter);
-              done();
-            });
-        });
-    });
-
-    it('report.removeAllFilters() returns promise that resolves with null if the request was accepted', function (done) {
-      // Arrange
-      iframeLoaded
-        .then(() => {
-          spyApp.clearFilters.and.returnValue(Promise.resolve(null));
-          // Act
-          report.removeAllFilters()
-            .then(response => {
-              // Assert
-              expect(spyApp.clearFilters).toHaveBeenCalled();
-              done();
-            });
-        });
-    });
-
-    it('report.removeAllFilters() with no arguments removes report level filters by sending DELETE report/allfilters', function (done) {
-      // Arrange
-      iframeLoaded
-        .then(() => {
-          spyApp.clearFilters.and.returnValue(Promise.resolve(null));
-          // Act
-          report.removeAllFilters()
-            .then(response => {
-              // Assert
-              expect(spyApp.clearFilters).toHaveBeenCalled();
-              done();
-            });
-        });
-    });
-  });
-
-  describe('filters (page level)', function () {
-    it('report.addFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        },
-        expectedError: {
-          message: 'invalid target'
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedError));
-          // Act
-          report.addFilter(testData.filter, testData.target)
-            .catch(error => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).not.toHaveBeenCalled();
-              expect(spyApp.addFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
-              done();
-            });
-        });
-    });
-
-    it('report.addFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-          spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.addFilter.and.returnValue(Promise.resolve(null));
-          // Act
-          report.addFilter(testData.filter, testData.target)
-            .then(response => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter, testData.target);
-              done();
-            });
-        });
-    });
-
-    it('report.updateFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        },
-        expectedError: {
-          message: 'invalid target'
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedError));
-          // Act
-          report.updateFilter(testData.filter, testData.target)
-            .catch(error => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).not.toHaveBeenCalled();
-              expect(spyApp.updateFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
-              done();
-            });
-        });
-    });
-
-    it('report.updateFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-          spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.updateFilter.and.returnValue(Promise.resolve(null));
-          // Act
-          report.updateFilter(testData.filter, testData.target)
-            .then(response => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter, testData.target);
-              done();
-            });
-        });
-    });
-
-    it('report.removeFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        },
-        expectedError: {
-          message: 'invalid target'
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedError));
-          // Act
-          report.removeFilter(testData.filter, testData.target)
-            .catch(error => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).not.toHaveBeenCalled();
-              expect(spyApp.removeFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
-              done();
-            });
-        });
-    });
-
-    it('report.removeFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IPageTarget>{
-          type: "page",
-          name: "page1"
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-          spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.removeFilter.and.returnValue(Promise.resolve(null));
-          // Act
-          report.removeFilter(testData.filter, testData.target)
-            .then(response => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter, testData.target);
-              done();
-            });
-        });
-    });
-  });
-
-  describe('filters (visual level)', function () {
-    it('report.addFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        },
-        expectedError: {
-          message: 'invalid target'
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedError));
-          // Act
-          report.addFilter(testData.filter, testData.target)
-            .catch(error => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).not.toHaveBeenCalled();
-              expect(spyApp.addFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
-              done();
-            });
-        });
-    });
-
-    it('report.addFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-          spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.addFilter.and.returnValue(Promise.resolve(null));
-          // Act
-          report.addFilter(testData.filter, testData.target)
-            .then(response => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.addFilter).toHaveBeenCalledWith(testData.filter, testData.target);
-              done();
-            });
-        });
-    });
-
-    it('report.updateFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        },
-        expectedError: {
-          message: 'invalid target'
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedError));
-          // Act
-          report.updateFilter(testData.filter, testData.target)
-            .catch(error => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).not.toHaveBeenCalled();
-              expect(spyApp.updateFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
-              done();
-            });
-        });
-    });
-
-    it('report.updateFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-          spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.updateFilter.and.returnValue(Promise.resolve(null));
-          // Act
-          report.updateFilter(testData.filter, testData.target)
-            .then(response => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.updateFilter).toHaveBeenCalledWith(testData.filter, testData.target);
-              done();
-            });
-        });
-    });
-
-    it('report.removeFilter(filter, target) returns promise that rejects with validation errors if target or filter is invalid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        },
-        expectedError: {
-          message: 'invalid target'
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.reject(testData.expectedError));
-          // Act
-          report.removeFilter(testData.filter, testData.target)
-            .catch(error => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).not.toHaveBeenCalled();
-              expect(spyApp.removeFilter).not.toHaveBeenCalled();
-              expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
-              done();
-            });
-        });
-    });
-
-    it('report.removeFilter(filter, target) returns promise that resolves with null if request is valid', function (done) {
-      // Arrange
-      const testData = {
-        filter: (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON(),
-        target: <models.IVisualTarget>{
-          type: "visual",
-          id: "visualId"
-        }
-      };
-
-      iframeLoaded
-        .then(() => {
-          spyApp.validateTarget.and.returnValue(Promise.resolve(null));
-          spyApp.validateFilter.and.returnValue(Promise.resolve(null));
-          spyApp.removeFilter.and.returnValue(Promise.resolve(null));
-          // Act
-          report.removeFilter(testData.filter, testData.target)
-            .then(response => {
-              // Assert
-              expect(spyApp.validateTarget).toHaveBeenCalledWith(testData.target);
-              expect(spyApp.validateFilter).toHaveBeenCalledWith(testData.filter);
-              expect(spyApp.removeFilter).toHaveBeenCalledWith(testData.filter, testData.target);
+              expect(spyApp.setFilters).toHaveBeenCalled();
               done();
             });
         });
@@ -5022,6 +3058,12 @@ describe('SDK-to-MockApp', function () {
             name: 'page1',
             displayName: 'Page 1'
           }
+        },
+        expectedEvent: {
+          detail: {
+            initiator: 'sdk',
+            page: report.page('page1')
+          }
         }
       };
 
@@ -5032,7 +3074,7 @@ describe('SDK-to-MockApp', function () {
         .then(response => {
           // Assert
           expect(testData.handler).toHaveBeenCalledWith(jasmine.any(CustomEvent));
-          expect(testData.handler).toHaveBeenCalledWith(jasmine.objectContaining({ detail: testData.simulatedPageChangeBody }));
+          expect(testData.handler).toHaveBeenCalledWith(jasmine.objectContaining(testData.expectedEvent));
           done();
         });
     });
@@ -5041,7 +3083,7 @@ describe('SDK-to-MockApp', function () {
       // Arrange
       const testData = {
         reportId: 'fakeReportId',
-        eventName: 'filterAdded',
+        eventName: 'filtersApplied',
         handler: jasmine.createSpy('handler'),
         handler2: jasmine.createSpy('handler2'),
         simulatedPageChangeBody: {

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -1907,7 +1907,7 @@ describe('SDK-to-HPM', function () {
           .catch(errors => {
             // Assert
             expect(spyHpm.get).toHaveBeenCalledWith('/report/filters', { uid: uniqueId }, iframe.contentWindow);
-            expect(errors).toEqual(testData.expectedErrors.body);
+            expect(errors).toEqual(jasmine.objectContaining(testData.expectedErrors.body));
             done();
           });
       });
@@ -1974,7 +1974,7 @@ describe('SDK-to-HPM', function () {
           .catch(errors => {
             // Assert
             expect(spyHpm.put).toHaveBeenCalledWith('/report/filters', testData.filters, { uid: uniqueId }, iframe.contentWindow);
-            expect(errors).toEqual(testData.expectedErrors.body);
+            expect(errors).toEqual(jasmine.objectContaining(testData.expectedErrors.body));
             done();
           });
       });
@@ -2193,7 +2193,7 @@ describe('SDK-to-HPM', function () {
           .catch(errors => {
             // Assert
             expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${page1.name}/filters`, testData.filters, { uid: uniqueId }, iframe.contentWindow);
-            expect(errors).toEqual(testData.expectedErrors.body);
+            expect(errors).toEqual(jasmine.objectContaining(testData.expectedErrors.body));
             done();
           });
       });
@@ -2286,7 +2286,7 @@ describe('SDK-to-HPM', function () {
           .catch(errors => {
             // Assert
             expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/active`, testData.page, { uid: uniqueId }, iframe.contentWindow);
-            expect(errors).toEqual(testData.response.body);
+            expect(errors).toEqual(jasmine.objectContaining(testData.response.body));
             done();
           });
       });
@@ -2352,7 +2352,7 @@ describe('SDK-to-HPM', function () {
           .catch(error => {
             // Assert
             expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${page1.name}/visuals`, { uid: uniqueId }, iframe.contentWindow);
-            expect(error).toEqual(testData.response.body);
+            expect(error).toEqual(jasmine.objectContaining(testData.response.body));
             done();
           });
       });
@@ -2416,7 +2416,7 @@ describe('SDK-to-HPM', function () {
           .catch(error => {
             // Assert
             expect(spyHpm.get).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, { uid: uniqueId }, iframe.contentWindow);
-            expect(error).toEqual(testData.expectedError.body);
+            expect(error).toEqual(jasmine.objectContaining(testData.expectedError.body));
             done();
           });
       });
@@ -2485,7 +2485,7 @@ describe('SDK-to-HPM', function () {
           .catch(errors => {
             // Assert
             expect(spyHpm.put).toHaveBeenCalledWith(`/report/pages/${visual1.page.name}/visuals/${visual1.name}/filters`, testData.filters, { uid: uniqueId }, iframe.contentWindow);
-            expect(errors).toEqual(testData.expectedErrors.body);
+            expect(errors).toEqual(jasmine.objectContaining(testData.expectedErrors.body));
             done();
           });
       });
@@ -2861,7 +2861,7 @@ describe('SDK-to-MockApp', function () {
                 // Assert
                 expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.loadConfig);
                 expect(spyApp.load).not.toHaveBeenCalled();
-                expect(errors).toEqual(testData.expectedErrors);
+                expect(errors).toEqual(jasmine.objectContaining(testData.expectedErrors));
                 done();
               });
           });
@@ -2959,7 +2959,7 @@ describe('SDK-to-MockApp', function () {
               .catch(error => {
                 // Assert
                 expect(spyApp.getFilters).toHaveBeenCalled();
-                expect(error).toEqual(testData.expectedError);
+                expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
                 done();
               });
           });
@@ -3129,7 +3129,7 @@ describe('SDK-to-MockApp', function () {
               .catch(error => {
                 // Assert
                 expect(spyApp.getFilters).toHaveBeenCalled();
-                expect(error).toEqual(testData.expectedError);
+                expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
                 done();
               });
           });
@@ -3241,7 +3241,7 @@ describe('SDK-to-MockApp', function () {
                 // Assert
                 expect(spyApp.validatePage).toHaveBeenCalled(); //.toHaveBeenCalledWith(page1);
                 expect(spyApp.getVisuals).not.toHaveBeenCalled();
-                expect(errors).toEqual(testData.errors);
+                expect(errors).toEqual(jasmine.objectContaining(testData.errors));
                 done();
               });
           });
@@ -3295,7 +3295,7 @@ describe('SDK-to-MockApp', function () {
                 // Assert
                 expect(spyApp.validatePage).toHaveBeenCalled(); //.toHaveBeenCalledWith(page1);
                 expect(spyApp.setPage).not.toHaveBeenCalled();
-                expect(errors).toEqual(testData.errors);
+                expect(errors).toEqual(jasmine.objectContaining(testData.errors));
                 done();
               });
           });
@@ -3354,7 +3354,7 @@ describe('SDK-to-MockApp', function () {
                 expect(spyApp.validatePage).toHaveBeenCalled(); //.toHaveBeenCalledWith(page1);
                 expect(spyApp.validateVisual).toHaveBeenCalled();
                 expect(spyApp.getFilters).not.toHaveBeenCalled();
-                expect(error).toEqual(testData.errors);
+                expect(error).toEqual(jasmine.objectContaining(testData.errors));
                 done();
               });
           });
@@ -3380,7 +3380,7 @@ describe('SDK-to-MockApp', function () {
                 expect(spyApp.validatePage).toHaveBeenCalled(); //.toHaveBeenCalledWith(page1);
                 expect(spyApp.validateVisual).toHaveBeenCalled();
                 expect(spyApp.getFilters).toHaveBeenCalled();
-                expect(error).toEqual(testData.expectedError);
+                expect(error).toEqual(jasmine.objectContaining(testData.expectedError));
                 done();
               });
           });

--- a/test/utility/mockApp.ts
+++ b/test/utility/mockApp.ts
@@ -13,16 +13,11 @@ export interface IApp {
   setPage(pageName: string): Promise<void>;
   validatePage(page: models.IPage): Promise<models.IError[]>;
   // Filters
+  getFilters(): Promise<models.IFilter[]>;
+  setFilters(filters: (models.IBasicFilter | models.IAdvancedFilter)[]): Promise<void>;
   validateFilter(filter: models.IFilter): Promise<models.IError[]>;
-  validateTarget(target: models.ITarget): Promise<models.IError[]>;
-  getFilters(target?: models.ITarget): Promise<models.IFilter[]>;
-  addFilter(filter: models.IFilter, target?: models.ITarget): Promise<void>;
-  updateFilter(filter: models.IFilter, target?: models.ITarget): Promise<void>;
-  removeFilter(filter: models.IFilter, target?: models.ITarget): Promise<void>;
-  clearFilters(target?: models.ITarget): Promise<void>;
-  toggleFilterPane(): Promise<void>;
   // Other
-  exportData(target: models.ITarget): Promise<void>;
+  exportData(): Promise<void>;
 }
 
 export const mockAppSpyObj = {
@@ -37,14 +32,9 @@ export const mockAppSpyObj = {
   setPage: jasmine.createSpy("setPage").and.returnValue(Promise.resolve(null)),
   validatePage: jasmine.createSpy("validatePage").and.returnValue(Promise.resolve(null)),
   // Filters
-  validateFilter: jasmine.createSpy("validateFilter").and.callFake(models.validateFilter),
-  validateTarget: jasmine.createSpy("validateTarget").and.callFake(models.validateTarget),
   getFilters: jasmine.createSpy("getFilters").and.returnValue(Promise.resolve(null)),
-  addFilter: jasmine.createSpy("addFilter").and.returnValue(Promise.resolve(null)),
-  updateFilter: jasmine.createSpy("updateFilter").and.returnValue(Promise.resolve(null)),
-  removeFilter: jasmine.createSpy("removeFilter").and.returnValue(Promise.resolve(null)),
-  clearFilters: jasmine.createSpy("clearFilters").and.returnValue(Promise.resolve(null)),
-  toggleFilterPane: jasmine.createSpy("toggleFilterPane").and.returnValue(Promise.resolve(null)),
+  setFilters: jasmine.createSpy("setFilters").and.returnValue(Promise.resolve(null)),
+  validateFilter: jasmine.createSpy("validateFilter").and.callFake(models.validateFilter),
   // Other
   exportData: jasmine.createSpy("exportData").and.returnValue(Promise.resolve(null)),
 
@@ -56,14 +46,9 @@ export const mockAppSpyObj = {
     mockAppSpyObj.getPages.calls.reset();
     mockAppSpyObj.setPage.calls.reset();
     mockAppSpyObj.validatePage.calls.reset();
-    mockAppSpyObj.validateFilter.calls.reset();
-    mockAppSpyObj.validateTarget.calls.reset();
     mockAppSpyObj.getFilters.calls.reset();
-    mockAppSpyObj.addFilter.calls.reset();
-    mockAppSpyObj.updateFilter.calls.reset();
-    mockAppSpyObj.removeFilter.calls.reset();
-    mockAppSpyObj.clearFilters.calls.reset();
-    mockAppSpyObj.toggleFilterPane.calls.reset();
+    mockAppSpyObj.setFilters.calls.reset();
+    mockAppSpyObj.validateFilter.calls.reset();
   }
 };
 

--- a/test/utility/mockApp.ts
+++ b/test/utility/mockApp.ts
@@ -7,11 +7,13 @@ export interface IApp {
   // Settings
   updateSettings(settings: models.ISettings): Promise<void>;
   validateSettings(settigns: models.ISettings): Promise<models.IError[]>;
-  
   // Pages
   getPages(): Promise<models.IPage>;
   setPage(pageName: string): Promise<void>;
   validatePage(page: models.IPage): Promise<models.IError[]>;
+  // Visuals
+  getVisuals(page: models.IPage): Promise<models.IVisual>;
+  validateVisual(visual: models.IVisual): Promise<models.IError[]>;
   // Filters
   getFilters(): Promise<models.IFilter[]>;
   setFilters(filters: (models.IBasicFilter | models.IAdvancedFilter)[]): Promise<void>;
@@ -31,6 +33,9 @@ export const mockAppSpyObj = {
   getPages: jasmine.createSpy("getPages").and.returnValue(Promise.resolve(null)),
   setPage: jasmine.createSpy("setPage").and.returnValue(Promise.resolve(null)),
   validatePage: jasmine.createSpy("validatePage").and.returnValue(Promise.resolve(null)),
+  // Visuals
+  getVisuals: jasmine.createSpy("getVisuals").and.returnValue(Promise.resolve(null)),
+  validateVisual: jasmine.createSpy("validateVisual").and.returnValue(Promise.resolve(null)),
   // Filters
   getFilters: jasmine.createSpy("getFilters").and.returnValue(Promise.resolve(null)),
   setFilters: jasmine.createSpy("setFilters").and.returnValue(Promise.resolve(null)),
@@ -46,9 +51,12 @@ export const mockAppSpyObj = {
     mockAppSpyObj.getPages.calls.reset();
     mockAppSpyObj.setPage.calls.reset();
     mockAppSpyObj.validatePage.calls.reset();
+    mockAppSpyObj.getVisuals.calls.reset();
+    mockAppSpyObj.validateVisual.calls.reset();
     mockAppSpyObj.getFilters.calls.reset();
     mockAppSpyObj.setFilters.calls.reset();
     mockAppSpyObj.validateFilter.calls.reset();
+
   }
 };
 

--- a/test/utility/mockReportEmbed.ts
+++ b/test/utility/mockReportEmbed.ts
@@ -76,7 +76,7 @@ export function setupMockApp(iframeContentWindow: Window, parentWindow: Window, 
     return app.validatePage(page)
       .then(() => {
         app.setPage(page)
-          .then(page => {
+          .then(() => {
             const initiator = "sdk";
             hpm.post(`/reports/${uniqueId}/events/pageChanged`, {
               initiator,
@@ -87,8 +87,8 @@ export function setupMockApp(iframeContentWindow: Window, parentWindow: Window, 
           });
         
         res.send(202);
-      }, error => {
-        res.send(400, error);
+      }, errors => {
+        res.send(400, errors);
       });
   });
   

--- a/test/utility/mockReportEmbed.ts
+++ b/test/utility/mockReportEmbed.ts
@@ -131,13 +131,21 @@ export function setupMockApp(iframeContentWindow: Window, parentWindow: Window, 
    * Phase 3
    */
   router.get('/report/pages/:pageName/filters', (req, res) => {
-    const pageName = req.params.pageName;
+    const page = {
+      name: req.params.pageName,
+      displayName: null
+    };
     
-    return app.getFilters()
-      .then(filters => {
-        res.send(200, filters);
-      }, error => {
-        res.send(500, error);
+    return app.validatePage(page)
+      .then(() => {
+        return app.getFilters()
+          .then(filters => {
+            res.send(200, filters);
+          }, error => {
+            res.send(500, error);
+          });
+      }, errors => {
+        res.send(400, errors);
       });
   });
 
@@ -170,6 +178,32 @@ export function setupMockApp(iframeContentWindow: Window, parentWindow: Window, 
       });
   });
 
+  router.get('/report/pages/:pageName/visuals/:visualName/filters', (req, res) => {
+    const pageName = req.params.pageName;
+    const visualName = req.params.visualName;
+    const uniqueId = req.headers['uid'];
+    const page: models.IPage = {
+      name: pageName,
+      displayName: null
+    };
+    const visual: models.IVisual = {
+      name: visualName
+    };
+
+    return app.validatePage(page)
+      .then(() => app.validateVisual(visual))
+      .then(() => {
+        return app.getFilters()
+          .then(filters => {
+            res.send(200, filters);
+          }, error => {
+            res.send(500, error);
+          });
+      }, errors => {
+        res.send(400, errors);
+      });
+  });
+
   router.put('/report/pages/:pageName/visuals/:visualName/filters', (req, res) => {
     const pageName = req.params.pageName;
     const visualName = req.params.visualName;
@@ -184,6 +218,7 @@ export function setupMockApp(iframeContentWindow: Window, parentWindow: Window, 
     };
 
     return app.validatePage(page)
+      .then(() => app.validateVisual(visual))
       .then(() => {
         return Promise.all(filters.map(filter => app.validateFilter(filter)));
       })
@@ -231,7 +266,25 @@ export function setupMockApp(iframeContentWindow: Window, parentWindow: Window, 
   /**
    * Phase 4
    */
-  // No work for router
+  router.get('/report/pages/:pageName/visuals', (req, res) => {
+    const uniqueId = req.headers['uid'];
+    const page = {
+      name: req.params.pageName,
+      displayName: null
+    };
+
+    return app.validatePage(page)
+      .then(() => {
+        return app.getVisuals(page)
+          .then(visuals => {
+            res.send(200, visuals);
+          }, error => {
+            res.send(500, error);
+          });
+      }, errors => {
+        res.send(400, errors);
+      });
+  });
   
   /**
    * Phase 5


### PR DESCRIPTION
Added Page and Visual objects
Added IFilterable
Updated powerbi-models dependency
Updated tests existing tests and added new ones for Page and Visual related actions.