### PR TITLE
Add exception to prevent attempting to embed with different type than previous embed type.  Add test.

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -247,6 +247,15 @@ export class Service implements IService {
       throw new Error(`Attempted to embed using config ${JSON.stringify(config)} on element ${element.outerHTML} which already has embedded comopnent associated, but could not find the existing comopnent in the list of active components. This could indicate the embeds list is out of sync with the DOM, or the component is referencing the incorrect HTML element.`);
     }
 
+    /**
+     * TODO: Dynamic embed type switching could be supported but there is work needed to prepare the service state and DOM cleanup.
+     * remove all event handlers from the DOM, then reset the element to initial state which removes iframe, and removes from list of embeds
+     * then we can call the embedNew function which would allow setting the proper embedUrl and construction of object based on the new type.
+     */
+    if (typeof config.type === "string" && config.type !== component.config.type) {
+      throw new Error(`Embedding on an existing element with a different type than the previous embed object is not supported.  Attempted to embed using config ${JSON.stringify(config)} on element ${element.outerHTML}, but the existing element contains an embed of type: ${this.config.type} which does not match the new type: ${config.type}`);
+    }
+
     component.load(<embed.IInternalEmbedConfiguration>config);
 
     return component;

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -140,6 +140,36 @@ describe('service', function () {
       expect(attemptEmbed).toThrowError(Error);
     });
 
+    it('if attempting to embed on existing element with different type than previous embed, throw error', function () {
+      // Arrange
+      const component = $('<div></div>')
+        .appendTo('#powerbi-fixture');
+
+      const reportEmbedConfig: embed.IEmbedConfiguration = {
+        type: "report",
+        id: "fakeReportId",
+        accessToken: "fakeAccessToken",
+        embedUrl: "fakeEmbedUrl"
+      };
+
+      const dashboardEmbedConfig: embed.IEmbedConfiguration = {
+        type: "dashboard",
+        id: "fakeDashboardId",
+        accessToken: "fakeAccessToken",
+        embedUrl: "fakeEmbedUrl"
+      };
+
+      powerbi.embed(component[0], reportEmbedConfig);
+
+      // Act
+      const attemptEmbed = () => {
+        powerbi.embed(component[0], dashboardEmbedConfig);
+      };
+
+      // Assert
+      expect(attemptEmbed).toThrowError(Error);
+    });
+
     it('if attempting to embed without specifying an embed url, throw error', function () {
       // Arrange
       const component = $('<div></div>')


### PR DESCRIPTION
Since the dashboard adds a new embed type and object, this could introduce some pitfalls for developers.  Adding this exception should add protection here, until we have proper support for this scenario.