### PR TITLE
[BREAKING] Update powerbi-models dependency to 0.8.0 which includes support for dashboard validation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "http-post-message": "^0.2.3",
-    "powerbi-models": "^0.7.4",
+    "powerbi-models": "^0.8.0",
     "powerbi-router": "^0.1.4",
     "window-post-message-proxy": "^0.2.4"
   },

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -40,6 +40,7 @@ export class Dashboard extends embed.Embed implements IDashboardNode {
      */
     constructor(service: service.Service, element: HTMLElement, config: embed.IEmbedConfiguration) {
         super(service, element, config);
+        this.loadPath = "/dashboard/load";
         Array.prototype.push.apply(this.allowedEvents, Dashboard.allowedEvents);
     }
 
@@ -79,4 +80,25 @@ export class Dashboard extends embed.Embed implements IDashboardNode {
 
         return dashboardId;
     }
+
+    /**
+   * Loads report using configuration object.
+   * 
+   * ```javascript
+   * dashboard.load({
+   *   type: 'dashboard',
+   *   id: '5dac7a4a-4452-46b3-99f6-a25915e0fe55',
+   *   accessToken: 'eyJ0eXA ... TaE2rTSbmg'
+   * })
+   *   .catch(error => { ... });
+   * ```
+   */
+  load(config: models.report.ILoadConfiguration): Promise<void> {
+    const errors = models.dashboard.validateLoad(config);
+    if (errors) {
+      throw errors;
+    }
+
+    return super.load(config);
+  }
 }

--- a/src/ifilterable.ts
+++ b/src/ifilterable.ts
@@ -13,14 +13,14 @@ export interface IFilterable {
    * 
    * @returns {(Promise<models.IFilter[]>)}
    */
-  getFilters(): Promise<models.IFilter[]>;
+  getFilters(): Promise<models.report.IFilter[]>;
   /**
    * Replaces all filters on the current object with the specified filter values.
    * 
    * @param {(models.IFilter[])} filters
    * @returns {Promise<void>}
    */
-  setFilters(filters: models.IFilter[]): Promise<void>;
+  setFilters(filters: models.report.IFilter[]): Promise<void>;
   /**
    * Removes all filters from the current object.
    * 

--- a/src/page.ts
+++ b/src/page.ts
@@ -63,11 +63,9 @@ export class Page implements IPageNode, IFilterable {
    * page.getFilters()
    *  .then(pages => { ... });
    * ```
-   * 
-   * @returns {(Promise<models.IFilter[]>)}
    */
-  getFilters(): Promise<models.IFilter[]> {
-    return this.report.service.hpm.get<models.IFilter[]>(`/report/pages/${this.name}/filters`, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
+  getFilters(): Promise<models.report.IFilter[]> {
+    return this.report.service.hpm.get<models.report.IFilter[]>(`/report/pages/${this.name}/filters`, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
       .then(response => response.body,
       response => {
         throw response.body;
@@ -81,11 +79,9 @@ export class Page implements IPageNode, IFilterable {
    * page.getVisuals()
    *   .then(visuals => { ... });
    * ```
-   * 
-   * @returns {Promise<Visual[]>}
    */
   getVisuals(): Promise<Visual[]> {
-    return this.report.service.hpm.get<models.IVisual[]>(`/report/pages/${this.name}/visuals`, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
+    return this.report.service.hpm.get<models.report.IVisual[]>(`/report/pages/${this.name}/visuals`, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
       .then(response => {
         return response.body
           .map(visual => {
@@ -119,7 +115,7 @@ export class Page implements IPageNode, IFilterable {
    * @returns {Promise<void>}
    */
   setActive(): Promise<void> {
-    const page: models.IPage = {
+    const page: models.report.IPage = {
       name: this.name,
       displayName: null
     };
@@ -138,10 +134,9 @@ export class Page implements IPageNode, IFilterable {
    *   .catch(errors => { ... });
    * ```
    * 
-   * @param {(models.IFilter[])} filters
    * @returns {Promise<void>}
    */
-  setFilters(filters: models.IFilter[]): Promise<void> {
+  setFilters(filters: models.report.IFilter[]): Promise<void> {
     return this.report.service.hpm.put<models.IError[]>(`/report/pages/${this.name}/filters`, filters, { uid: this.report.config.uniqueId }, this.report.iframe.contentWindow)
       .catch(response => {
         throw response.body;

--- a/src/report.ts
+++ b/src/report.ts
@@ -53,6 +53,7 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
     const configCopy = utils.assign({ settings }, config);
 
     super(service, element, configCopy);
+    this.loadPath = "/report/load";
     Array.prototype.push.apply(this.allowedEvents, Report.allowedEvents);
   }
 
@@ -91,8 +92,8 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
    * 
    * @returns {Promise<models.IFilter[]>}
    */
-  getFilters(): Promise<models.IFilter[]> {
-    return this.service.hpm.get<models.IFilter[]>(`/report/filters`, { uid: this.config.uniqueId }, this.iframe.contentWindow)
+  getFilters(): Promise<models.report.IFilter[]> {
+    return this.service.hpm.get<models.report.IFilter[]>(`/report/filters`, { uid: this.config.uniqueId }, this.iframe.contentWindow)
       .then(response => response.body,
       response => {
         throw response.body;
@@ -127,7 +128,7 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
    * @returns {Promise<Page[]>}
    */
   getPages(): Promise<Page[]> {
-    return this.service.hpm.get<models.IPage[]>('/report/pages', { uid: this.config.uniqueId }, this.iframe.contentWindow)
+    return this.service.hpm.get<models.report.IPage[]>('/report/pages', { uid: this.config.uniqueId }, this.iframe.contentWindow)
       .then(response => {
         return response.body
           .map(page => {
@@ -136,6 +137,36 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
       }, response => {
         throw response.body;
       });
+  }
+
+  /**
+   * Loads report using configuration object.
+   * 
+   * ```javascript
+   * report.load({
+   *   type: 'report',
+   *   id: '5dac7a4a-4452-46b3-99f6-a25915e0fe55',
+   *   accessToken: 'eyJ0eXA ... TaE2rTSbmg',
+   *   settings: {
+   *     navContentPaneEnabled: false
+   *   },
+   *   pageName: "DefaultPage",
+   *   filters: [
+   *     {
+   *        ...  DefaultReportFilter ...
+   *     }
+   *   ]
+   * })
+   *   .catch(error => { ... });
+   * ```
+   */
+  load(config: models.report.ILoadConfiguration): Promise<void> {
+    const errors = models.report.validateLoad(config);
+    if (errors) {
+      throw errors;
+    }
+
+    return super.load(config);
   }
 
   /**
@@ -215,7 +246,7 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
    * @returns {Promise<void>}
    */
   setPage(pageName: string): Promise<void> {
-    const page: models.IPage = {
+    const page: models.report.IPage = {
       name: pageName,
       displayName: null
     };
@@ -243,7 +274,7 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
    * @param {(models.IFilter[])} filters
    * @returns {Promise<void>}
    */
-  setFilters(filters: models.IFilter[]): Promise<void> {
+  setFilters(filters: models.report.IFilter[]): Promise<void> {
     return this.service.hpm.put<models.IError[]>(`/report/filters`, filters, { uid: this.config.uniqueId }, this.iframe.contentWindow)
       .catch(response => {
         throw response.body;
@@ -266,7 +297,7 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
    * @param {models.ISettings} settings
    * @returns {Promise<void>}
    */
-  updateSettings(settings: models.ISettings): Promise<void> {
+  updateSettings(settings: models.report.ISettings): Promise<void> {
     return this.service.hpm.patch<models.IError[]>('/report/settings', settings, { uid: this.config.uniqueId }, this.iframe.contentWindow)
       .catch(response => {
         throw response.body;

--- a/src/service.ts
+++ b/src/service.ts
@@ -339,7 +339,7 @@ export class Service implements IService {
 
       if (event.name === 'pageChanged') {
         const pageKey = 'newPage';
-        const page: models.IPage = value[pageKey];
+        const page: models.report.IPage = value[pageKey];
         if (!page) {
           throw new Error(`Page model not found at 'event.value.${pageKey}'.`);
         }

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -50,8 +50,8 @@ export class Visual implements IVisualNode, IFilterable {
    * 
    * @returns {(Promise<models.IFilter[]>)}
    */
-  getFilters(): Promise<models.IFilter[]> {
-    return this.page.report.service.hpm.get<models.IFilter[]>(`/report/pages/${this.page.name}/visuals/${this.name}/filters`, { uid: this.page.report.config.uniqueId }, this.page.report.iframe.contentWindow)
+  getFilters(): Promise<models.report.IFilter[]> {
+    return this.page.report.service.hpm.get<models.report.IFilter[]>(`/report/pages/${this.page.name}/visuals/${this.name}/filters`, { uid: this.page.report.config.uniqueId }, this.page.report.iframe.contentWindow)
       .then(response => response.body,
       response => {
         throw response.body;
@@ -82,7 +82,7 @@ export class Visual implements IVisualNode, IFilterable {
    * @param {(models.IFilter[])} filters
    * @returns {Promise<void>}
    */
-  setFilters(filters: models.IFilter[]): Promise<void> {
+  setFilters(filters: models.report.IFilter[]): Promise<void> {
     return this.page.report.service.hpm.put<models.IError[]>(`/report/pages/${this.page.name}/visuals/${this.name}/filters`, filters, { uid: this.page.report.config.uniqueId }, this.page.report.iframe.contentWindow)
       .catch(response => {
         throw response.body;

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -972,7 +972,7 @@ describe('Protocol', function () {
           .then(() => {
             spyApp.getPages.and.returnValue(Promise.resolve(testData.expectedPages));
             // Act
-            hpm.get<models.IPage[]>('/report/pages')
+            hpm.get<models.report.IPage[]>('/report/pages')
               .then(response => {
                 // Assert
                 expect(spyApp.getPages).toHaveBeenCalled();
@@ -997,7 +997,7 @@ describe('Protocol', function () {
           .then(() => {
             spyApp.getPages.and.returnValue(Promise.reject(testData.expectedError));
             // Act
-            hpm.get<models.IPage[]>('/report/pages')
+            hpm.get<models.report.IPage[]>('/report/pages')
               .catch(response => {
                 // Assert
                 expect(spyApp.getPages).toHaveBeenCalled();
@@ -1199,7 +1199,7 @@ describe('Protocol', function () {
             spyApp.getFilters.and.returnValue(Promise.resolve(testData.filters));
 
             // Act
-            hpm.get<models.IFilter[]>('/report/filters')
+            hpm.get<models.report.IFilter[]>('/report/filters')
               .then(response => {
                 // Assert
                 expect(spyApp.getFilters).toHaveBeenCalled();
@@ -1225,7 +1225,7 @@ describe('Protocol', function () {
             spyApp.getFilters.and.returnValue(Promise.reject(testData.error));
 
             // Act
-            hpm.get<models.IFilter[]>('/report/filters')
+            hpm.get<models.report.IFilter[]>('/report/filters')
               .catch(response => {
                 // Assert
                 expect(spyApp.getFilters).toHaveBeenCalled();
@@ -1351,7 +1351,7 @@ describe('Protocol', function () {
             spyApp.getFilters.and.returnValue(Promise.resolve(testData.filters));
 
             // Act
-            hpm.get<models.IFilter[]>('/report/pages/xyz/filters')
+            hpm.get<models.report.IFilter[]>('/report/pages/xyz/filters')
               .then(response => {
                 // Assert
                 expect(spyApp.getFilters).toHaveBeenCalled();
@@ -1377,7 +1377,7 @@ describe('Protocol', function () {
             spyApp.getFilters.and.returnValue(Promise.reject(testData.error));
 
             // Act
-            hpm.get<models.IFilter[]>('/report/pages/xyz/filters')
+            hpm.get<models.report.IFilter[]>('/report/pages/xyz/filters')
               .catch(response => {
                 // Assert
                 expect(spyApp.getFilters).toHaveBeenCalled();
@@ -2079,8 +2079,8 @@ describe('SDK-to-HPM', function () {
         const testData = {
           response: {
             body: [
-              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+              (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
             ]
           }
         };
@@ -2123,8 +2123,8 @@ describe('SDK-to-HPM', function () {
         const testData = {
           response: {
             body: [
-              (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-              (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+              (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+              (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
             ]
           }
         };
@@ -2145,8 +2145,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
         };
 
@@ -2161,8 +2161,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ],
           expectedErrors: {
             body: [
@@ -2189,8 +2189,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
         };
 
@@ -2472,8 +2472,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ],
           response: {
             body: []
@@ -2493,8 +2493,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ],
           expectedErrors: {
             body: [
@@ -2521,8 +2521,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
         };
 
@@ -2767,8 +2767,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
         };
 
@@ -2785,8 +2785,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ],
           expectedErrors: {
             body: [
@@ -2813,8 +2813,8 @@ describe('SDK-to-HPM', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
-            (new models.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
+            (new models.report.BasicFilter({ table: "Cars", measure: "Make" }, "In", ["subaru", "honda"])).toJSON(),
+            (new models.report.AdvancedFilter({ table: "Cars", measure: "Make" }, "And", [{ value: "subaru", operator: "None" }, { value: "honda", operator: "Contains" }])).toJSON()
           ]
         };
 
@@ -3317,7 +3317,7 @@ describe('SDK-to-MockApp', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
+            (new models.report.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
           ],
           expectedErrors: [
             {
@@ -3344,7 +3344,7 @@ describe('SDK-to-MockApp', function () {
       it('report.setFilters(filters) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
         // Arrange
         const testData = {
-          filters: [(new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()]
+          filters: [(new models.report.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()]
         };
 
         iframeLoaded
@@ -3523,7 +3523,7 @@ describe('SDK-to-MockApp', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
+            (new models.report.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
           ],
           expectedErrors: [
             {
@@ -3550,7 +3550,7 @@ describe('SDK-to-MockApp', function () {
       it('page.setFilters(filters) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
         // Arrange
         const testData = {
-          filters: [(new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()]
+          filters: [(new models.report.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()]
         };
 
         iframeLoaded
@@ -3778,7 +3778,7 @@ describe('SDK-to-MockApp', function () {
         // Arrange
         const testData = {
           filters: [
-            (new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
+            (new models.report.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()
           ],
           errors: [
             {
@@ -3809,7 +3809,7 @@ describe('SDK-to-MockApp', function () {
       it('visual.setFilters(filters) returns promise that resolves with null if filter was valid and request is accepted', function (done) {
         // Arrange
         const testData = {
-          filters: [(new models.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()]
+          filters: [(new models.report.BasicFilter({ table: "cars", column: "make" }, "In", ["subaru", "honda"])).toJSON()]
         };
 
         iframeLoaded

--- a/test/utility/mockApp.ts
+++ b/test/utility/mockApp.ts
@@ -2,22 +2,22 @@ import * as models from 'powerbi-models';
 
 export interface IApp {
   // Load
-  load(config: models.ILoadConfiguration): Promise<void>;
-  validateLoad(config: models.ILoadConfiguration): Promise<models.IError[]>;
+  load(config: models.report.ILoadConfiguration): Promise<void>;
+  validateLoad(config: models.report.ILoadConfiguration): Promise<models.IError[]>;
   // Settings
-  updateSettings(settings: models.ISettings): Promise<void>;
-  validateSettings(settigns: models.ISettings): Promise<models.IError[]>;
+  updateSettings(settings: models.report.ISettings): Promise<void>;
+  validateSettings(settigns: models.report.ISettings): Promise<models.IError[]>;
   // Pages
-  getPages(): Promise<models.IPage>;
+  getPages(): Promise<models.report.IPage>;
   setPage(pageName: string): Promise<void>;
-  validatePage(page: models.IPage): Promise<models.IError[]>;
+  validatePage(page: models.report.IPage): Promise<models.IError[]>;
   // Visuals
-  getVisuals(page: models.IPage): Promise<models.IVisual>;
-  validateVisual(visual: models.IVisual): Promise<models.IError[]>;
+  getVisuals(page: models.report.IPage): Promise<models.report.IVisual>;
+  validateVisual(visual: models.report.IVisual): Promise<models.IError[]>;
   // Filters
-  getFilters(): Promise<models.IFilter[]>;
-  setFilters(filters: models.IFilter[]): Promise<void>;
-  validateFilter(filter: models.IFilter): Promise<models.IError[]>;
+  getFilters(): Promise<models.report.IFilter[]>;
+  setFilters(filters: models.report.IFilter[]): Promise<void>;
+  validateFilter(filter: models.report.IFilter): Promise<models.IError[]>;
   // Other
   print(): Promise<void>;
   refreshData(): Promise<void>;
@@ -27,10 +27,10 @@ export interface IApp {
 export const mockAppSpyObj = {
   // Load
   load: jasmine.createSpy("load").and.returnValue(Promise.resolve(null)),
-  validateLoad: jasmine.createSpy("validateLoad").and.callFake(models.validateLoad),
+  validateLoad: jasmine.createSpy("validateLoad").and.callFake(models.report.validateLoad),
   // Settings
   updateSettings: jasmine.createSpy("updateSettings").and.returnValue(Promise.resolve(null)),
-  validateSettings: jasmine.createSpy("validateSettings").and.callFake(models.validateSettings),
+  validateSettings: jasmine.createSpy("validateSettings").and.callFake(models.report.validateSettings),
   // Pages
   getPages: jasmine.createSpy("getPages").and.returnValue(Promise.resolve(null)),
   setPage: jasmine.createSpy("setPage").and.returnValue(Promise.resolve(null)),
@@ -41,7 +41,7 @@ export const mockAppSpyObj = {
   // Filters
   getFilters: jasmine.createSpy("getFilters").and.returnValue(Promise.resolve(null)),
   setFilters: jasmine.createSpy("setFilters").and.returnValue(Promise.resolve(null)),
-  validateFilter: jasmine.createSpy("validateFilter").and.callFake(models.validateFilter),
+  validateFilter: jasmine.createSpy("validateFilter").and.callFake(models.report.validateFilter),
   // Other
   print: jasmine.createSpy("print").and.returnValue(Promise.resolve(null)),
   refreshData: jasmine.createSpy("refreshData").and.returnValue(Promise.resolve(null)),

--- a/test/utility/mockEmbed.ts
+++ b/test/utility/mockEmbed.ts
@@ -181,7 +181,7 @@ export function setupEmbedMockApp(iframeContentWindow: Window, parentWindow: Win
     const pageName = req.params.pageName;
     const uniqueId = req.headers['uid'];
     const filters = req.body;
-    const page: models.IPage = {
+    const page: models.report.IPage = {
       name: pageName,
       displayName: null
     };
@@ -210,11 +210,11 @@ export function setupEmbedMockApp(iframeContentWindow: Window, parentWindow: Win
     const pageName: string = req.params.pageName;
     const visualName: string = req.params.visualName;
     const uniqueId = req.headers['uid'];
-    const page: models.IPage = {
+    const page: models.report.IPage = {
       name: pageName,
       displayName: null
     };
-    const visual: models.IVisual = {
+    const visual: models.report.IVisual = {
       name: visualName,
       title: "",
       type: ""
@@ -239,11 +239,11 @@ export function setupEmbedMockApp(iframeContentWindow: Window, parentWindow: Win
     const visualName = req.params.visualName;
     const uniqueId = req.headers['uid'];
     const filters = req.body;
-    const page: models.IPage = {
+    const page: models.report.IPage = {
       name: pageName,
       displayName: null
     };
-    const visual: models.IVisual = {
+    const visual: models.report.IVisual = {
       name: visualName,
       title: "",
       type: ""


### PR DESCRIPTION
Updating all the related files to use new `report` and `dashboard` namespaces to access parts of `powerbi-models` library.

This also addresses the splitting of `load` method into `Report` and `Dashboard` specific overrides that Joey did not do.  If there is a cleaner way, I would be interested to get feedback on that.

*This is breaking change which would require merging to a 3.x release*

ot quite sure how to best to handle this one, but I think we should probably try to merge master up to 2.2.0 which would have the print, reload, and refresh code and data selection, then later start the 3.0.0.   Hopefully we have an idea of what we want to add to 2.x and what will be breaking for 3.x. The only other thing I know of is the `IFilter` change with `type` property.



