### PR TITLE
Non-breaking update to powerbi-models dependency to 0.9.0 which has support for validateDashboardLoad.  Update embed load to call abstract validate method which is provided by concrete Report and Dashboard classes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "http-post-message": "^0.2.3",
-    "powerbi-models": "^0.7.4",
+    "powerbi-models": "^0.9.0",
     "powerbi-router": "^0.1.4",
     "window-post-message-proxy": "^0.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "http-post-message": "^0.2.3",
-    "powerbi-models": "^0.9.0",
+    "powerbi-models": "^0.9.1",
     "powerbi-router": "^0.1.4",
     "window-post-message-proxy": "^0.2.4"
   },

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -40,6 +40,7 @@ export class Dashboard extends embed.Embed implements IDashboardNode {
      */
     constructor(service: service.Service, element: HTMLElement, config: embed.IEmbedConfiguration) {
         super(service, element, config);
+        this.loadPath = "/dashboard/load";
         Array.prototype.push.apply(this.allowedEvents, Dashboard.allowedEvents);
     }
 
@@ -78,5 +79,12 @@ export class Dashboard extends embed.Embed implements IDashboardNode {
         }
 
         return dashboardId;
+    }
+
+    /**
+     * Validate load configuration.
+     */
+    validate(config: models.IDashboardLoadConfiguration): models.IError[] {
+      return models.validateDashboardLoad(config);
     }
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -53,6 +53,7 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
     const configCopy = utils.assign({ settings }, config);
 
     super(service, element, configCopy);
+    this.loadPath = "/report/load";
     Array.prototype.push.apply(this.allowedEvents, Report.allowedEvents);
   }
 
@@ -271,5 +272,12 @@ export class Report extends embed.Embed implements IReportNode, IFilterable {
       .catch(response => {
         throw response.body;
       });
+  }
+
+  /**
+   * Validate load configuration.
+   */
+  validate(config: models.IReportLoadConfiguration): models.IError[] {
+    return models.validateReportLoad(config);
   }
 }

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -1,3 +1,4 @@
+import * as models from 'powerbi-models';
 import { Embed } from './embed';
 
 /**
@@ -16,6 +17,13 @@ export class Tile extends Embed {
    * @returns {string}
    */
   getId(): string {
-    throw Error('Not implemented. Embedding tiles is not supported yet.');
+    throw new Error('Not implemented. Embedding tiles is not supported yet.');
+  }
+
+  /**
+   * Validate load configuration.
+   */
+  validate(config: any): models.IError[] {
+    throw new Error('Not implemented. Embedding tiles is not supported yet.');
   }
 }

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -750,22 +750,22 @@ describe('Protocol', function () {
 
         iframeLoaded
           .then(() => {
-            spyApp.validateLoad.and.returnValue(Promise.reject(null));
+            spyApp.validateReportLoad.and.returnValue(Promise.reject(null));
 
             // Act
             hpm.post<models.IError>('/report/load', testData.load, { uid: testData.uniqueId })
               .then(() => {
                 expect(false).toBe(true);
-                spyApp.validateLoad.calls.reset();
+                spyApp.validateReportLoad.calls.reset();
                 done();
               })
               .catch(response => {
                 // Assert
-                expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.load);
-                expect(spyApp.load).not.toHaveBeenCalledWith(testData.load);
+                expect(spyApp.validateReportLoad).toHaveBeenCalledWith(testData.load);
+                expect(spyApp.reportLoad).not.toHaveBeenCalledWith(testData.load);
                 expect(response.statusCode).toEqual(400);
                 // Cleanup
-                spyApp.validateLoad.calls.reset();
+                spyApp.validateReportLoad.calls.reset();
                 done();
               });
           });
@@ -784,17 +784,17 @@ describe('Protocol', function () {
 
         iframeLoaded
           .then(() => {
-            spyApp.validateLoad.and.returnValue(Promise.resolve(null));
+            spyApp.validateReportLoad.and.returnValue(Promise.resolve(null));
             // Act
             hpm.post<void>('/report/load', testData.load)
               .then(response => {
                 // Assert
-                expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.load);
-                expect(spyApp.load).toHaveBeenCalledWith(testData.load);
+                expect(spyApp.validateReportLoad).toHaveBeenCalledWith(testData.load);
+                expect(spyApp.reportLoad).toHaveBeenCalledWith(testData.load);
                 expect(response.statusCode).toEqual(202);
                 // Cleanup
-                spyApp.validateLoad.calls.reset();
-                spyApp.load.calls.reset();
+                spyApp.validateReportLoad.calls.reset();
+                spyApp.reportLoad.calls.reset();
                 done();
               });
           });
@@ -822,19 +822,19 @@ describe('Protocol', function () {
 
         iframeLoaded
           .then(() => {
-            spyApp.load.and.returnValue(Promise.resolve(testData.load));
+            spyApp.reportLoad.and.returnValue(Promise.resolve(testData.load));
 
             // Act
             hpm.post<void>('/report/load', testData.load, { uid: testData.uniqueId })
               .then(response => {
                 setTimeout(() => {
                   // Assert
-                  expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.load);
-                  expect(spyApp.load).toHaveBeenCalledWith(testData.load);
+                  expect(spyApp.validateReportLoad).toHaveBeenCalledWith(testData.load);
+                  expect(spyApp.reportLoad).toHaveBeenCalledWith(testData.load);
                   expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
                   // Cleanup
-                  spyApp.validateLoad.calls.reset();
-                  spyApp.load.calls.reset();
+                  spyApp.validateReportLoad.calls.reset();
+                  spyApp.reportLoad.calls.reset();
                   done();
                 });
               });
@@ -864,19 +864,19 @@ describe('Protocol', function () {
 
         iframeLoaded
           .then(() => {
-            spyApp.load.and.returnValue(Promise.reject(testData.error));
+            spyApp.reportLoad.and.returnValue(Promise.reject(testData.error));
 
             // Act
             hpm.post<void>('/report/load', testData.load, { uid: testData.uniqueId })
               .then(response => {
                 setTimeout(() => {
                   // Assert
-                  expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.load);
-                  expect(spyApp.load).toHaveBeenCalledWith(testData.load);
+                  expect(spyApp.validateReportLoad).toHaveBeenCalledWith(testData.load);
+                  expect(spyApp.reportLoad).toHaveBeenCalledWith(testData.load);
                   expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(testExpectedEvent));
                   // Cleanup
-                  spyApp.validateLoad.calls.reset();
-                  spyApp.load.calls.reset();
+                  spyApp.validateReportLoad.calls.reset();
+                  spyApp.reportLoad.calls.reset();
                   done();
                 });
               });
@@ -899,17 +899,17 @@ describe('Protocol', function () {
 
         iframeLoaded
           .then(() => {
-            spyApp.validateLoad.and.returnValue(Promise.resolve(null));
+            spyApp.validateDashboardLoad.and.returnValue(Promise.resolve(null));
             // Act
             hpm.post<void>('/dashboard/load', testData.load)
               .then(response => {
                 // Assert
-                expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.load);
-                expect(spyApp.load).toHaveBeenCalledWith(testData.load);
+                expect(spyApp.validateDashboardLoad).toHaveBeenCalledWith(testData.load);
+                expect(spyApp.dashboardLoad).toHaveBeenCalledWith(testData.load);
                 expect(response.statusCode).toEqual(202);
                 // Cleanup
-                spyApp.validateLoad.calls.reset();
-                spyApp.load.calls.reset();
+                spyApp.validateDashboardLoad.calls.reset();
+                spyApp.dashboardLoad.calls.reset();
                 done();
               });
           });
@@ -930,22 +930,22 @@ describe('Protocol', function () {
 
         iframeLoaded
           .then(() => {
-            spyApp.validateLoad.and.returnValue(Promise.reject(null));
+            spyApp.validateDashboardLoad.and.returnValue(Promise.reject(null));
 
             // Act
             hpm.post<models.IError>('/dashboard/load', testData.load, { uid: testData.uniqueId })
               .then(() => {
                 expect(false).toBe(true);
-                spyApp.validateLoad.calls.reset();
+                spyApp.validateDashboardLoad.calls.reset();
                 done();
               })
               .catch(response => {
                 // Assert
-                expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.load);
-                expect(spyApp.load).not.toHaveBeenCalledWith(testData.load);
+                expect(spyApp.validateDashboardLoad).toHaveBeenCalledWith(testData.load);
+                expect(spyApp.dashboardLoad).not.toHaveBeenCalledWith(testData.load);
                 expect(response.statusCode).toEqual(400);
                 // Cleanup
-                spyApp.validateLoad.calls.reset();
+                spyApp.validateDashboardLoad.calls.reset();
                 done();
               });
           });
@@ -1093,7 +1093,7 @@ describe('Protocol', function () {
                 expect(response.statusCode).toEqual(202);
                 expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(expectedEvent));
                 // Cleanup
-                spyApp.validateLoad.calls.reset();
+                spyApp.validateReportLoad.calls.reset();
                 spyApp.setPage.calls.reset();
                 done();
               });
@@ -1132,7 +1132,7 @@ describe('Protocol', function () {
                 expect(response.statusCode).toEqual(202);
                 expect(spyHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining(expectedEvent));
                 // Cleanup
-                spyApp.validateLoad.calls.reset();
+                spyApp.validateReportLoad.calls.reset();
                 spyApp.setPage.calls.reset();
                 done();
               });
@@ -3125,7 +3125,8 @@ describe('SDK-to-MockApp', function () {
     iframeHpm2 = setupEmbedMockApp(iframe2.contentWindow, window, logMessages, 'SDK-to-MockApp IframeWpmp2');
 
     // Reset load handler
-    spyApp.validateLoad.calls.reset();
+    spyApp.validateReportLoad.calls.reset();
+    spyApp.validateDashboardLoad.calls.reset();
     spyApp.reset();
 
     const iframe1Loaded = new Promise<void>((resolve, reject) => {
@@ -3170,13 +3171,13 @@ describe('SDK-to-MockApp', function () {
 
         iframeLoaded
           .then(() => {
-            spyApp.validateLoad.and.returnValue(Promise.reject(testData.expectedErrors));
+            spyApp.validateReportLoad.and.returnValue(Promise.reject(testData.expectedErrors));
             // Act
             report.load(testData.loadConfig)
               .catch(errors => {
                 // Assert
-                expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.loadConfig);
-                expect(spyApp.load).not.toHaveBeenCalled();
+                expect(spyApp.validateReportLoad).toHaveBeenCalledWith(testData.loadConfig);
+                expect(spyApp.reportLoad).not.toHaveBeenCalled();
                 expect(errors).toEqual(jasmine.objectContaining(testData.expectedErrors));
                 done();
               });
@@ -3194,14 +3195,14 @@ describe('SDK-to-MockApp', function () {
 
         iframeLoaded
           .then(() => {
-            spyApp.validateLoad.and.returnValue(Promise.resolve(null));
-            spyApp.load.and.returnValue(Promise.resolve(null));
+            spyApp.validateReportLoad.and.returnValue(Promise.resolve(null));
+            spyApp.reportLoad.and.returnValue(Promise.resolve(null));
             // Act
             report.load(testData.loadConfig)
               .then(response => {
                 // Assert
-                expect(spyApp.validateLoad).toHaveBeenCalledWith(testData.loadConfig);
-                expect(spyApp.load).toHaveBeenCalledWith(testData.loadConfig);
+                expect(spyApp.validateReportLoad).toHaveBeenCalledWith(testData.loadConfig);
+                expect(spyApp.reportLoad).toHaveBeenCalledWith(testData.loadConfig);
                 expect(response).toEqual(undefined);
                 done();
               });

--- a/test/utility/mockApp.ts
+++ b/test/utility/mockApp.ts
@@ -2,8 +2,10 @@ import * as models from 'powerbi-models';
 
 export interface IApp {
   // Load
-  load(config: models.IReportLoadConfiguration): Promise<void>;
-  validateLoad(config: models.IReportLoadConfiguration): Promise<models.IError[]>;
+  dashboardLoad(config: models.IDashboardLoadConfiguration): Promise<void>;
+  validateDashboardLoad(config: models.IDashboardLoadConfiguration): Promise<models.IError[]>;
+  reportLoad(config: models.IReportLoadConfiguration): Promise<void>;
+  validateReportLoad(config: models.IReportLoadConfiguration): Promise<models.IError[]>;
   // Settings
   updateSettings(settings: models.ISettings): Promise<void>;
   validateSettings(settigns: models.ISettings): Promise<models.IError[]>;
@@ -26,8 +28,10 @@ export interface IApp {
 
 export const mockAppSpyObj = {
   // Load
-  load: jasmine.createSpy("load").and.returnValue(Promise.resolve(null)),
-  validateLoad: jasmine.createSpy("validateLoad").and.callFake(models.validateReportLoad),
+  dashboardLoad: jasmine.createSpy("dashboardLoad").and.returnValue(Promise.resolve(null)),
+  validateDashboardLoad: jasmine.createSpy("validateDashboardLoad").and.callFake(models.validateDashboardLoad),
+  reportLoad: jasmine.createSpy("reportLoad").and.returnValue(Promise.resolve(null)),
+  validateReportLoad: jasmine.createSpy("validateReportLoad").and.callFake(models.validateReportLoad),
   // Settings
   updateSettings: jasmine.createSpy("updateSettings").and.returnValue(Promise.resolve(null)),
   validateSettings: jasmine.createSpy("validateSettings").and.callFake(models.validateSettings),
@@ -48,8 +52,10 @@ export const mockAppSpyObj = {
   exportData: jasmine.createSpy("exportData").and.returnValue(Promise.resolve(null)),
 
   reset() {
-    mockAppSpyObj.load.calls.reset();
-    mockAppSpyObj.validateLoad.calls.reset();
+    mockAppSpyObj.dashboardLoad.calls.reset();
+    mockAppSpyObj.validateDashboardLoad.calls.reset();
+    mockAppSpyObj.reportLoad.calls.reset();
+    mockAppSpyObj.validateReportLoad.calls.reset();
     mockAppSpyObj.updateSettings.calls.reset();
     mockAppSpyObj.validateSettings.calls.reset();
     mockAppSpyObj.getPages.calls.reset();

--- a/test/utility/mockApp.ts
+++ b/test/utility/mockApp.ts
@@ -2,8 +2,8 @@ import * as models from 'powerbi-models';
 
 export interface IApp {
   // Load
-  load(config: models.ILoadConfiguration): Promise<void>;
-  validateLoad(config: models.ILoadConfiguration): Promise<models.IError[]>;
+  load(config: models.IReportLoadConfiguration): Promise<void>;
+  validateLoad(config: models.IReportLoadConfiguration): Promise<models.IError[]>;
   // Settings
   updateSettings(settings: models.ISettings): Promise<void>;
   validateSettings(settigns: models.ISettings): Promise<models.IError[]>;
@@ -27,7 +27,7 @@ export interface IApp {
 export const mockAppSpyObj = {
   // Load
   load: jasmine.createSpy("load").and.returnValue(Promise.resolve(null)),
-  validateLoad: jasmine.createSpy("validateLoad").and.callFake(models.validateLoad),
+  validateLoad: jasmine.createSpy("validateLoad").and.callFake(models.validateReportLoad),
   // Settings
   updateSettings: jasmine.createSpy("updateSettings").and.returnValue(Promise.resolve(null)),
   validateSettings: jasmine.createSpy("validateSettings").and.callFake(models.validateSettings),

--- a/test/utility/mockEmbed.ts
+++ b/test/utility/mockEmbed.ts
@@ -47,9 +47,9 @@ export function setupEmbedMockApp(iframeContentWindow: Window, parentWindow: Win
   router.post('/dashboard/load', (req, res) => {
     const uniqueId = req.headers['uid'];
     const loadConfig = req.body;
-    return app.validateLoad(loadConfig)
+    return app.validateDashboardLoad(loadConfig)
       .then(() => {
-        app.load(loadConfig)
+        app.dashboardLoad(loadConfig)
           .then(() => {
             const initiator = "sdk";
             hpm.post(`/dashboards/${uniqueId}/events/loaded`, {
@@ -71,9 +71,9 @@ export function setupEmbedMockApp(iframeContentWindow: Window, parentWindow: Win
   router.post('/report/load', (req, res) => {
     const uniqueId = req.headers['uid'];
     const loadConfig = req.body;
-    return app.validateLoad(loadConfig)
+    return app.validateReportLoad(loadConfig)
       .then(() => {
-        app.load(loadConfig)
+        app.reportLoad(loadConfig)
           .then(() => {
             const initiator = "sdk";
             hpm.post(`/reports/${uniqueId}/events/loaded`, {


### PR DESCRIPTION
Although the powerbi-models@0.8.0 had a better scalability and semantics the namespace is breaking change and would have caused breaking change for consumers of powerbi-client.  We decided to revert and refactor to a different change which is more sublte and allows powerbi-client to consume it without being a breaking change since it's usage of validation methods is internal.

Also, note that we use `abstract validate` method in the `embed` class which enforces that it is called and is implemented as opposed to the previous implementation which extended the `load` method and relied on developer calling correct code.

Main feedback looking for is to actually re-confirm it's non-breaking even though there is breaking change in dependency since `validateLoad` changed to `validateReportLoad` etc.