### PR TITLE
Calm Down Noise In Web Inspector

### DIFF
--- a/src/factories.ts
+++ b/src/factories.ts
@@ -27,6 +27,7 @@ export const wpmpFactory: IWpmpFactory = (name?: string, logMessages?: boolean, 
       getTrackingProperties: hpm.HttpPostMessage.getTrackingProperties,
     },
     isErrorMessage: hpm.HttpPostMessage.isErrorMessage,
+    suppressWarnings: true,
     name,
     logMessages,
     eventSourceOverrideWindow


### PR DESCRIPTION
Calm down the noise in web inspector by adding `suppressWarnings`.