### PR TITLE
Replacing inline styles

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -536,8 +536,8 @@ export abstract class Embed {
     if(!this.iframe) {
       var iframeContent = document.createElement("iframe");
       var embedUrl = this.config.uniqueId ? utils.addParamToUrl(this.config.embedUrl, 'uid', this.config.uniqueId) : this.config.embedUrl;
-      iframeContent.style.width="100%";
-      iframeContent.style.height="100%";
+      iframeContent.style.width = '100%';
+      iframeContent.style.height = '100%';
       iframeContent.setAttribute("src", embedUrl);
       iframeContent.setAttribute("scrolling", "no");
       iframeContent.setAttribute("allowfullscreen", "true");

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -536,7 +536,8 @@ export abstract class Embed {
     if(!this.iframe) {
       var iframeContent = document.createElement("iframe");
       var embedUrl = this.config.uniqueId ? utils.addParamToUrl(this.config.embedUrl, 'uid', this.config.uniqueId) : this.config.embedUrl;
-      iframeContent.setAttribute("style", "width:100%;height:100%;");
+      iframeContent.style.width="100%;
+      iframeContent.style.height="100%;
       iframeContent.setAttribute("src", embedUrl);
       iframeContent.setAttribute("scrolling", "no");
       iframeContent.setAttribute("allowfullscreen", "true");

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -536,8 +536,8 @@ export abstract class Embed {
     if(!this.iframe) {
       var iframeContent = document.createElement("iframe");
       var embedUrl = this.config.uniqueId ? utils.addParamToUrl(this.config.embedUrl, 'uid', this.config.uniqueId) : this.config.embedUrl;
-      iframeContent.style.width="100%;
-      iframeContent.style.height="100%;
+      iframeContent.style.width="100%";
+      iframeContent.style.height="100%";
       iframeContent.setAttribute("src", embedUrl);
       iframeContent.setAttribute("scrolling", "no");
       iframeContent.setAttribute("allowfullscreen", "true");


### PR DESCRIPTION
Changed:
iframeContent.setAttribute("style", "width:100%;height:100%;");

To:
iframeContent.style.width="100%;
iframeContent.style.height="100%;

This means that a content-security-policy website header can be set to allow for a more secure implementation.