### PR TITLE
Add sandbox attribute to the iframe

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -749,6 +749,7 @@ export abstract class Embed {
       iframeContent.setAttribute("src", embedUrl);
       iframeContent.setAttribute("scrolling", "no");
       iframeContent.setAttribute("allowfullscreen", "true");
+      iframeContent.setAttribute("sandbox", "allow-scripts allow-same-origin")
       const node = this.element;
       while (node.firstChild) {
         node.removeChild(node.firstChild);


### PR DESCRIPTION
Based on https://community.powerbi.com/t5/Service/Power-BI-Embedded-iframe-sandbox-attribute/m-p/2362079  

We want to add sandbox attribute for safe embedding of your reports in our application. I tried to find another way, but the library currently doesn't allow us to pass the attribute in any way.